### PR TITLE
Only include autoPatchelfHook on linux

### DIFF
--- a/foundry-bin/default.nix
+++ b/foundry-bin/default.nix
@@ -17,9 +17,10 @@ in
     };
 
     nativeBuildInputs = with pkgs; [
-      autoPatchelfHook
       pkg-config
       openssl
+    ] ++ lib.optionals stdenv.isLinux [
+      autoPatchelfHook
     ];
 
     installPhase = ''


### PR DESCRIPTION
`autoPatchelfHook` will fail on non-linux systems. See https://github.com/NixOS/nixpkgs/pull/163924 for context.

Closes #2 