### PR TITLE
Add new released package for "linux_arm64"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     flake-utils.lib.eachSystem [
       "x86_64-linux"
       "x86_64-darwin"
+      "aarch64-linux"
       "aarch64-darwin"
     ] (system:
       let

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -30,6 +30,10 @@ cat > releases.nix << EOF
       url = "$(get_url linux_amd64)";
       sha256 = "$(get_hash linux_amd64)";
     };
+    "aarch64-linux" = {
+      url = "$(get_url linux_arm64)";
+      sha256 = "$(get_hash linux_arm64)";
+    }; 
     "x86_64-darwin" = {
       url = "$(get_url darwin_amd64)";
       sha256 = "$(get_hash darwin_amd64)";


### PR DESCRIPTION
Noticed that one of the artifacts in the nightly releases for foundry-rs/foundry was missing.
Ran 'update.sh' locally + checked everything with 'nix flake check'. I wasn't able to test on an actual 'aarch64-linux' setup but hey, should be fine for now. 🤷