### PR TITLE
Add Anvil to foundry binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Make a `flake.nix` in your solidity project directory:
 }
 ```
 
-Then run `nix develop` to enter a shell with foundry binaries (`forge` and `cast`) present.
+Then run `nix develop` to enter a shell with foundry binaries (`forge`, `cast` and `anvil`) present.
 
 Running `nix flake update` will repin to the latest foundry release from this repo (auto-updates daily).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # foundry.nix
-Nix overlay for [foundry-rs/foundry](https://github.com/foundry-rs/foundry/) (including `forge` and `cast`)
+Nix overlay for [foundry-rs/foundry](https://github.com/foundry-rs/foundry/) (including `forge`, `cast` and `anvil`)
 
 This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release.
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,10 @@
           type = "app";
           program = "${defaultPackage}/bin/forge";
         };
+        apps.anvil = {
+          type = "app";
+          program = "${defaultPackage}/bin/anvil";
+        };
 
         defaultApp = apps.forge;
         defaultPackage = foundry-bin;

--- a/foundry-bin/default.nix
+++ b/foundry-bin/default.nix
@@ -25,11 +25,13 @@ in
 
     installPhase = ''
     mkdir -p $out/bin
-    mv forge cast $out/bin/
+    mv forge cast anvil $out/bin/
     '';
 
     doInstallCheck = true;
     installCheckPhase = ''
     $out/bin/forge --version > /dev/null
+    $out/bin/cast --version > /dev/null
+    $out/bin/anvil --version > /dev/null
     '';
   }


### PR DESCRIPTION
Simply made Anvil accessible in the foundry binaries.

[Anvil](https://github.com/foundry-rs/foundry/blob/master/anvil): local Ethereum node, akin to Ganache, Hardhat Network.

Ran `anvil` locally following `nix develop` within repo. Looking good 👍

![image](https://user-images.githubusercontent.com/16673837/167203687-ec3dcb22-96d2-4ca2-a617-5b9a93ae5f66.png)
