### PR TITLE
Undefined variable fix

### DIFF
--- a/foundry-bin/default.nix
+++ b/foundry-bin/default.nix
@@ -25,7 +25,7 @@ in
     ];
 
     installPhase = let
-      path = lib.makeBinPath [ pkgs.git ];
+      path = pkgs.lib.makeBinPath [ pkgs.git ];
     in ''
     set -e
     mkdir -p $out/bin


### PR DESCRIPTION
Without this change, I get
```
error: undefined variable 'lib'

       at /nix/store/raw0f6l6v32p7wnbb9lzb4jz7c3gyvn8-source/foundry-bin/default.nix:28:14:

           27|     installPhase = let
           28|       path = lib.makeBinPath [ pkgs.git ];
             |              ^
           29|     in ''
(use '--show-trace' to show detailed location information)
```
related to #10 I believe