### PR TITLE
Fix the monthly update.sh error again and revert the release.nix breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # foundry.nix
 Nix overlay for [foundry-rs/foundry](https://github.com/foundry-rs/foundry/) (including `forge`, `cast` and `anvil`)
 
-This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release.
+This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release, which are pruned from upstream regularly. We also maintain a `monthly` branch for permanent releases that are not pruned.
 
 ## Usage: Showing off nix
 
@@ -42,7 +42,7 @@ Make a `flake.nix` in your solidity project directory:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
-    foundry.url = "github:shazow/foundry.nix";
+    foundry.url = "github:shazow/foundry.nix/monthly"; # Use monthly branch for permanent releases
   };
 
   outputs = { self, nixpkgs, utils, foundry }:

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-21T14:21:39Z";
+  timestamp = "2023-01-22T22:22:10Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0y5m4cmqzi5sb4yp30613f115caspxymmwss9ixwvipqm8dnzvpw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0rcyzzb3zbzrqnb1aiivq1l19wx81mvj48r8pnp4ljay7xvwvprn";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1kslfj2a99sjh17hsy0ii40rl5gj4p7dsqfvn12rw4lkxp1s2j02";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0p1crkpnybwhhi13rxlq7ljf1djswg6050dl0j34q0c1n6hwcdhw";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "15ga99ns2x1fk5jn47yz1pxm5a7f0vnwmd6y38fn3h13pbm9awaa";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0ssrx7qilz8mzw7g15i8mqlfb42jyi75kl0ddbwm19big77yx9hz";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1jz3iriib2gr2f9mv68xy94qqf2fvwhmk8crbxa0piy3lyqbp11b";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "10kmxnmfzkclnsa6b2rvqx4x5m3yi3jjk80kwcqjgqjssm32xbk2";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-16T22:00:09Z";
+  timestamp = "2023-01-17T19:05:30Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "00inx77fy6xv41ac22cixwbj15d28342cd87m2awb9v3iimi86q6";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0wbbgbsww0yh28ixlm6ac480wxiwqx2q4sqqi9dv803pa2s42rfg";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0yn23hf2c7fjcrr7a5z2128d4yvrjq40lp1w8sfqvvkc3zlj6nhb";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "13fmm4xg0kxb91af3ar63x4vdng6ih22j82dmag2b40bx39v1p3m";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0kvnk074bgqf8v72yzrc7slsq6pr5rqm43gxpvv7xmfdixvm6h4w";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0m0y0yja5kwmcj6aapmawwg8f6nigwxfjmw58332gwcqz4sv00yf";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1r96nda9b4l49vjjfqxh1ckvbnfjldyyb74sk1hcwrnm2gw0nqk7";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1nw0k8aps136sppsdlxw1cwd1mlfnjcan72y6407vki4c9gachfg";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-23T16:15:59Z";
+  timestamp = "2023-01-24T15:48:39Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "03g4di635n8xg1vbdgdpppvh3xarjwr20ip0p1lzfph6z1vnld0s";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0vbzjiz4bmqpp94af0albh3p4ah7x0slf9yflgrg52qkrmcr63hr";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1nlp9l4vmhsb61dl3v0cc82xlvbj9ig6pxl3kv0dc76bx5yk19dw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0s9y20l22gdfbg86n17my0n47b8zgk87x1lm7apyj65gyszf77kb";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "059xn1v4i0c4qmaky8ym1gav7wcxm53karw2sd68yjgxs0fi8ng2";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0p0zv87z881wwgyrpy2war4w8msb029k237hblssnbzyiw9y81jp";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "12846v61xrcik4v3wd6c0lcdsx1h5jy2c07kxzqygavdnrf37q6w";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0dhqj88fxdh2h9m6a1yg6256gin8377bad7ghqzbavwy3cdszsd9";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "10nxinsn2acnii6d9z5lqxzv0vji68zjd64bcv5xr46bfm7yraa6";
+      sha256 = "04lbcfrf85ylmgz006nsky5c4f5p5vls5q22c6ihcmjfa3by7x8r";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1f2h4gg1v4q60gwl54af08xiijvq7f15liv7f1q2mxfgiv3n6v7x";
+      sha256 = "098px38c3mnnpkyh94845a34ilvdmn2lb44kbasiqgddz7vwqs67";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1rd027j66f30ng815hxbww0mss4wif3p315wph8dgz3xh21l459r";
+      sha256 = "0xbshkmminid4h2dyx21i1317d0dg14gi413i946wjiqvp4wxs92";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1g1c0rc4yx7g1wxxapg5az3jig8l027bb3n872jg7pdxziynxs6m";
+      sha256 = "1zvz3lfkq2w1skqai57wr1vk06ypz2y6blzk24k33rry16g6szv1";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "16yyb8vx94f9fvf0jwxlwsik9653zy5r7rp41i9z5603zcv47262";
+      sha256 = "0lvxgnq4v5yk7pqamfjpsgb0vpsn247vsrc7sif0ply6dx1r35zf";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "16574kyaabrbky3zi11s5y67qa9k1kac1lfxxa67wpw96wsx50xk";
+      sha256 = "1scidx0154m0kv0gi9nzxc00ff3v97d3rwg2w5n6ybzms4m07628";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1i4fzdlr2xxh60ngm0r4729rqd6l6fxjc860nnripj1q095lj8k2";
+      sha256 = "1hmgd0rymlsnswf0qjkmdjabifas1v7d93ad6132c4dlwr1xvih8";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "02cdhvcncvk4bifwlxpwk7jy8p0r9khkm14w8mn401nm9ga1na6m";
+      sha256 = "1fj9458pi28licisz6yycxykvvq09v57vfp1492p485a0p450spj";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-13T12:39:29Z";
+  timestamp = "2023-01-14T15:54:05Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0lmk7p5a586wz4f37yigiqi2d7c3c94hpxavyivybcg6vka8a5sx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1giadnwb6gyfh9ydyp83ib00djr16if5zhlx81mddbiillf636sb";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0kpivmh1zm6j1jm7b4x76p8r4w77hzd9hxj3l18yg8z97d8baa55";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0x17abc1c1il4rc9yia0s5jlyllih5fn9z4r5qrn6lw8md59c0zv";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0pjqh3g368i0f4kn76vvqd0d4afp1rc6afy9v4x85q97nyw5w6dz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1nqazm2fnfsf3j9sciqsyyjr8r57yafnq2s66gw1rlxj2w4cnz7i";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1qlamnawlzxpifzzwi89al7c6pwqk27x771lmfyymazz3qg2pl29";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0aaxszxqwn1qvnq70n742mvsa9590x8d2zz9bi25iyc82my1cm1a";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-11T17:37:07Z";
+  timestamp = "2023-01-13T12:39:29Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0lvxgnq4v5yk7pqamfjpsgb0vpsn247vsrc7sif0ply6dx1r35zf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0lmk7p5a586wz4f37yigiqi2d7c3c94hpxavyivybcg6vka8a5sx";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1scidx0154m0kv0gi9nzxc00ff3v97d3rwg2w5n6ybzms4m07628";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0kpivmh1zm6j1jm7b4x76p8r4w77hzd9hxj3l18yg8z97d8baa55";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1hmgd0rymlsnswf0qjkmdjabifas1v7d93ad6132c4dlwr1xvih8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0pjqh3g368i0f4kn76vvqd0d4afp1rc6afy9v4x85q97nyw5w6dz";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1fj9458pi28licisz6yycxykvvq09v57vfp1492p485a0p450spj";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d5f03836dc5820ba95dadd736d0b17a3c7b4583/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1qlamnawlzxpifzzwi89al7c6pwqk27x771lmfyymazz3qg2pl29";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-31T18:00:22Z";
+  timestamp = "2023-02-02T19:42:24Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1h7w82x01ng2hs69qf26kfrrs8pay5swkxfxc17d3fxp5ffzigzi";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0xvp2jipivdw22kwvr8ia29wb29kxl2za1rmwxvgkkagk97laknr";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "182cj50chx4wyn725rj1z2r15i2b0h1hmxc6ln22g66nyjl9mx57";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1gy9qrgxr9l33lqjir37maqrr74y2n23z5cna6pvvbmbkdfrxixp";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "140ivxiqsnz0d3i9ih4axxi2a7lwbx9nrnddxi4brkg1dps1f88j";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1qlshbysx75frq5fsmw8yrx3z49id3s48k40x2fxmr9ayhi377fl";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1i8rhcci2b9iz1zisyr1fkdpyxza4k8cx0qbm5kw152a5d217k47";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1zwpw8n86yjqv59xpdb1rzrscnaykcgkgbhigdmk3as1vr03vb78";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-29T13:52:18Z";
+  timestamp = "2023-01-30T15:21:31Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "197fbd1hg3ii20v5gg5qmwp328j6y10kiziap463skk4zkjbn8sb";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "101fmcykrpylsq443nmkdfblryw1m76ynw45jkq396vnl2n6v04d";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "06zci5qyv47y0b55ic7b3lb0za3ykqwq9smmgsfifnwjilzs0lj0";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0xxlw0w7fkrfb395dqww2x4nddmwfw5b38fdzcb4z2lby46m9dz6";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1hk05p9jz3i2wdx5f78lpzywl7nch0w4ay4b94bv22bxm1qdbpqh";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1md2zrmq934mg2gh486a761wvdhj0p645dszqpw42abpixy5ryjb";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1m4m0n338vimmpz2p2ix6asnkmdy4x9svx1mwwgfyyvzxlba623i";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "06g0ic69kfmncndlhnvvalaidyq1x5418znkzjz5w5blx62j5qbx";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-10T21:29:58Z";
+  timestamp = "2023-01-11T17:37:07Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1p0mpdgs501afc3sha67yccdc1p50y3f2a895vg73ag977vkkv52";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "16yyb8vx94f9fvf0jwxlwsik9653zy5r7rp41i9z5603zcv47262";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "15n35r85phbygypf7rpcbp92kc98b88cs8332swdam2yn9r52cyx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "16574kyaabrbky3zi11s5y67qa9k1kac1lfxxa67wpw96wsx50xk";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0l16yrh9sjddgjlm9g5mgx665jbh74ccpvfvrpm8kafylly2sam4";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1i4fzdlr2xxh60ngm0r4729rqd6l6fxjc860nnripj1q095lj8k2";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1740k0v3vhdm6sysak6nkacdbxnsrf7yxmk30p4nhlnp3szw9fsx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-925626516788be4274ba70f47e82ba30f58b5fbb/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "02cdhvcncvk4bifwlxpwk7jy8p0r9khkm14w8mn401nm9ga1na6m";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-26T23:13:34Z";
+  timestamp = "2023-01-27T12:41:26Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "16k34ab7wl4mq9b9fgld6pzfxadj833jzmg593mnaldhdwr0z8kf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0905l8swzq26a5gxl12i6syasn2rs2kdbyz9i8rlxab1as5b956l";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1y5n4v57qdz43szf1bzs61vbq9p3niaazclvwydazvxcpwcjp9s5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1v5qqm17m1lz0lqivrrmm8ffcmxzjgxg1gh6lss0hlg8iqc9ara2";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "168a6aqz0qd0svyqfb01l9rvv4np9np86fxa6q9i2vlcvqibi91z";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1xjx82397k02m5b4pwaa0zl9b3mq6i21r3wmim4scsw15k5f61qg";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "081ciyxjnvjqsmhi4m13kyg3bzj9v0hii7qy40rh4ik6mly0670r";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0mb91lxy4ac1s6p41b88jchmid38zp6jn5axbwd9v39si8zi8a8p";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-30T15:21:31Z";
+  timestamp = "2023-01-31T18:00:22Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "101fmcykrpylsq443nmkdfblryw1m76ynw45jkq396vnl2n6v04d";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1sk41gd4wd87hlfjfslhxsrxqbc881wm30qh2pwxqixm15x8jj6p";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0xxlw0w7fkrfb395dqww2x4nddmwfw5b38fdzcb4z2lby46m9dz6";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1sj3678fjpc3c99xbbd32w2bv6kjh6n26i4qyr2vglh0hgyqs7s3";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1md2zrmq934mg2gh486a761wvdhj0p645dszqpw42abpixy5ryjb";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0y93jz7av13i1hf5rahq5k60n9dbrfvqvf0czi272613xn5ymwxl";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5c2db0babf02e1f1016b1471de3b21593cb06b56/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "06g0ic69kfmncndlhnvvalaidyq1x5418znkzjz5w5blx62j5qbx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1s60s97cdpaqn0hs2bm9j5ygjz1iwm0xya9aw9izhar17dibmyjl";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-02-05T21:52:55Z";
+  timestamp = "2023-02-06T18:46:11Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1fk4qvin4n8f8mm3gk07963fbsbciqhqdb45aylbvdhngjg20vnv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "08fv8qb4615ls9h499vcsdf3fgnb3rapj91crc4h9spx96lmi746";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1mglmclyixyk42l2j2p36xhbrd4bdb57rlv12y2w52xf9cbjg8a8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "15dq281cf2wxcy7nxaz5yw5rzp9kddwdjr5iv0ipm9m38i4jyfv5";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0wchp7kcvwpq2vhad5bbhgf2m8kw61c9qs6m4hrl98mh8hqrmyfv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "16ay3j52h58by2vx2f96ar0q71dbk0ykaar8b6kd435m27xk34vx";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1hbjj18f1xn4njfbxhq2wfr2jfxp9rxrl61s6ncbmb19m6xaxg0n";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-24T15:48:39Z";
+  timestamp = "2023-01-25T18:31:19Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0vbzjiz4bmqpp94af0albh3p4ah7x0slf9yflgrg52qkrmcr63hr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1q9crlzj7hqmzfqk2kjhm1k0slbnd5l1plb74x1fzzd7c3pla0d7";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0s9y20l22gdfbg86n17my0n47b8zgk87x1lm7apyj65gyszf77kb";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0cm6ddlspq6qjq1ww1gjv4dgy0j2z21azp1rcfh5x7g7akxl2pdy";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0p0zv87z881wwgyrpy2war4w8msb029k237hblssnbzyiw9y81jp";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1lz34n5ndb54dajcjg00xrxwi6p86qak5w3qrp9x4cgf9fj7p7kl";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b83b316f5a0e0917a404a0007b53522ec796a7b2/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0dhqj88fxdh2h9m6a1yg6256gin8377bad7ghqzbavwy3cdszsd9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0bkp9mx490xn4382qaiakwhir0hfkd3cbyvy2642jmmfp1jcvw9g";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-14T15:54:05Z";
+  timestamp = "2023-01-16T22:00:09Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0sf73s0d01dx3gz9cgyn0psd9ln0fqn5i4w7lnrr8j7hrr7n6lz1";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "00inx77fy6xv41ac22cixwbj15d28342cd87m2awb9v3iimi86q6";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0fhrcp0xk7xfn7ca64sgw0slhj7xilbr9mkng2qnfx3bqwlcb9a4";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0yn23hf2c7fjcrr7a5z2128d4yvrjq40lp1w8sfqvvkc3zlj6nhb";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0msvg04vijqrj8wrl1fr1dnnnrhiz8919jk3a9vsx7ajjjq1fwi1";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0kvnk074bgqf8v72yzrc7slsq6pr5rqm43gxpvv7xmfdixvm6h4w";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1r1w38a28hqv6j7y6hdb7qqbsm6vh7dshg3fy6alxq8gn16lv58m";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e1eb91208b304ec9c44831db2945cd1d6ac209cb/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1r96nda9b4l49vjjfqxh1ckvbnfjldyyb74sk1hcwrnm2gw0nqk7";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-02-04T11:37:27Z";
+  timestamp = "2023-02-05T21:52:55Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "13z8ddbpgi2di42zm1vg4zm6xs486icy9078lnhsg526kbxw2d96";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1fk4qvin4n8f8mm3gk07963fbsbciqhqdb45aylbvdhngjg20vnv";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1hnxzykv2153wwq25xv99d2hg9xdbmrlx775dddx72bsxnin6ggn";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1mglmclyixyk42l2j2p36xhbrd4bdb57rlv12y2w52xf9cbjg8a8";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0k4n94r68fab5j970y42hqsppy8ihaq1r0mgv4mcfd31ih21amdl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0wchp7kcvwpq2vhad5bbhgf2m8kw61c9qs6m4hrl98mh8hqrmyfv";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0jibx10w6j7qrmdia2w557yj9hxgam6xm7d7hp0iqvfryvmcxsbd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b45456717ffae1af65acdc71099f8cb95e6683a0/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1hbjj18f1xn4njfbxhq2wfr2jfxp9rxrl61s6ncbmb19m6xaxg0n";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-02-02T19:42:24Z";
+  timestamp = "2023-02-03T12:04:27Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0xvp2jipivdw22kwvr8ia29wb29kxl2za1rmwxvgkkagk97laknr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0lbrkpqvzp9hq4816j0iaz8rf5fhjqaaw5q06jfr35757phns9jy";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1gy9qrgxr9l33lqjir37maqrr74y2n23z5cna6pvvbmbkdfrxixp";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "06yx40a116zyb6hlkykpkcr7mq5wzazj5118i25nrnnjj0akvgh0";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1qlshbysx75frq5fsmw8yrx3z49id3s48k40x2fxmr9ayhi377fl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1hgifllwsghz3glk0pfr6lxylsc2kakzj05lc0wgz2f9llknirk5";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6157d4a6f2566dcc3e7af2e81c782e18efa85959/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1zwpw8n86yjqv59xpdb1rzrscnaykcgkgbhigdmk3as1vr03vb78";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "06r8h4l2qfgnd1x2cp1jr4lrkwlmnffl1h8pbr58np5bqbr1pnhx";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-27T12:41:26Z";
+  timestamp = "2023-01-28T12:32:14Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0905l8swzq26a5gxl12i6syasn2rs2kdbyz9i8rlxab1as5b956l";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "089h573j78azvpld7kqr2plbjh2baq5yq4ha60qykdx61m2dvjsx";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1v5qqm17m1lz0lqivrrmm8ffcmxzjgxg1gh6lss0hlg8iqc9ara2";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1riyffah8gyzyn04s1yh72inx0dvdfihx1823x96xa15bq0ppkda";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1xjx82397k02m5b4pwaa0zl9b3mq6i21r3wmim4scsw15k5f61qg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1iq2kdx8i6wbzpi35kv90hpxclw1x9dibw3w97kgais0hi99bakd";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3ca87239f088882cbf501d035366846c52fc6007/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0mb91lxy4ac1s6p41b88jchmid38zp6jn5axbwd9v39si8zi8a8p";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "04hcl445chi49kyrzbdn4r6lq4sadr4qhza0qpzpsy4yrg04ivb4";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1sk41gd4wd87hlfjfslhxsrxqbc881wm30qh2pwxqixm15x8jj6p";
+      sha256 = "1h7w82x01ng2hs69qf26kfrrs8pay5swkxfxc17d3fxp5ffzigzi";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1sj3678fjpc3c99xbbd32w2bv6kjh6n26i4qyr2vglh0hgyqs7s3";
+      sha256 = "182cj50chx4wyn725rj1z2r15i2b0h1hmxc6ln22g66nyjl9mx57";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0y93jz7av13i1hf5rahq5k60n9dbrfvqvf0czi272613xn5ymwxl";
+      sha256 = "140ivxiqsnz0d3i9ih4axxi2a7lwbx9nrnddxi4brkg1dps1f88j";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-cd7850bfb64a4babb07bf5dd6fe5ebac664449cf/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1s60s97cdpaqn0hs2bm9j5ygjz1iwm0xya9aw9izhar17dibmyjl";
+      sha256 = "1i8rhcci2b9iz1zisyr1fkdpyxza4k8cx0qbm5kw152a5d217k47";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-02-03T12:04:27Z";
+  timestamp = "2023-02-04T11:37:27Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0lbrkpqvzp9hq4816j0iaz8rf5fhjqaaw5q06jfr35757phns9jy";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "13z8ddbpgi2di42zm1vg4zm6xs486icy9078lnhsg526kbxw2d96";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "06yx40a116zyb6hlkykpkcr7mq5wzazj5118i25nrnnjj0akvgh0";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1hnxzykv2153wwq25xv99d2hg9xdbmrlx775dddx72bsxnin6ggn";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1hgifllwsghz3glk0pfr6lxylsc2kakzj05lc0wgz2f9llknirk5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0k4n94r68fab5j970y42hqsppy8ihaq1r0mgv4mcfd31ih21amdl";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ca9de1316ea2ec402b6d4e4282ae3bf349e3c0af/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "06r8h4l2qfgnd1x2cp1jr4lrkwlmnffl1h8pbr58np5bqbr1pnhx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e53c0d2338e447bb2468d2c2b183fd21df6b3494/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0jibx10w6j7qrmdia2w557yj9hxgam6xm7d7hp0iqvfryvmcxsbd";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-19T20:28:29Z";
+  timestamp = "2023-01-20T13:18:32Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0dvisxm0snahyhvyhfl4a7s8sjrl82v1wqjdqnq1i1ppv44pi7ys";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1g8mi3vljsbbyc53ya8w0mk0053zsl60cspvrwlmin7hs8w5zzrk";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "05m35rwnqr4iyk670jd44szifk2vkk67hzy068yf2rmdrls06jch";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0gc1c1y66wy8bp12h6advmalsv35r2kvlcca4plbf3lk21dbglc1";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1hgvic21fb2rjcw707cxbknx9j196qgzaq6xx8swqwhpbfjjvfwf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0iph63v9i46avyiksc8g3j9ycym03fsn9x1cfrg04qqh3xwxg1wc";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1v8mq6481rljdk5hgyf2fc9wdw2pqfdfvzv1gpl6753n3d7jqn4q";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "01r533m8wa7lg3922ysgs7q9a0whxsls9za0w8vy04in189c6nr5";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-22T22:22:10Z";
+  timestamp = "2023-01-23T16:15:59Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0rcyzzb3zbzrqnb1aiivq1l19wx81mvj48r8pnp4ljay7xvwvprn";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "03g4di635n8xg1vbdgdpppvh3xarjwr20ip0p1lzfph6z1vnld0s";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0p1crkpnybwhhi13rxlq7ljf1djswg6050dl0j34q0c1n6hwcdhw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1nlp9l4vmhsb61dl3v0cc82xlvbj9ig6pxl3kv0dc76bx5yk19dw";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0ssrx7qilz8mzw7g15i8mqlfb42jyi75kl0ddbwm19big77yx9hz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "059xn1v4i0c4qmaky8ym1gav7wcxm53karw2sd68yjgxs0fi8ng2";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e367728c737c70dcd927cff367f5a3b283a4bc/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "10kmxnmfzkclnsa6b2rvqx4x5m3yi3jjk80kwcqjgqjssm32xbk2";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e7ef3c22bc01fcde1e80ade6ca59ccd682d79ee5/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "12846v61xrcik4v3wd6c0lcdsx1h5jy2c07kxzqygavdnrf37q6w";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-25T18:31:19Z";
+  timestamp = "2023-01-26T23:13:34Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1q9crlzj7hqmzfqk2kjhm1k0slbnd5l1plb74x1fzzd7c3pla0d7";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "16k34ab7wl4mq9b9fgld6pzfxadj833jzmg593mnaldhdwr0z8kf";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0cm6ddlspq6qjq1ww1gjv4dgy0j2z21azp1rcfh5x7g7akxl2pdy";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1y5n4v57qdz43szf1bzs61vbq9p3niaazclvwydazvxcpwcjp9s5";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1lz34n5ndb54dajcjg00xrxwi6p86qak5w3qrp9x4cgf9fj7p7kl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "168a6aqz0qd0svyqfb01l9rvv4np9np86fxa6q9i2vlcvqibi91z";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-aeba75e4799f1e11e3daba98d967b83e286b0c4a/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0bkp9mx490xn4382qaiakwhir0hfkd3cbyvy2642jmmfp1jcvw9g";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-849fd61ba19294a504af700945ad1b92efb9f8b9/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "081ciyxjnvjqsmhi4m13kyg3bzj9v0hii7qy40rh4ik6mly0670r";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-28T12:32:14Z";
+  timestamp = "2023-01-29T13:52:18Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "089h573j78azvpld7kqr2plbjh2baq5yq4ha60qykdx61m2dvjsx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "197fbd1hg3ii20v5gg5qmwp328j6y10kiziap463skk4zkjbn8sb";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1riyffah8gyzyn04s1yh72inx0dvdfihx1823x96xa15bq0ppkda";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "06zci5qyv47y0b55ic7b3lb0za3ykqwq9smmgsfifnwjilzs0lj0";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1iq2kdx8i6wbzpi35kv90hpxclw1x9dibw3w97kgais0hi99bakd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1hk05p9jz3i2wdx5f78lpzywl7nch0w4ay4b94bv22bxm1qdbpqh";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3a15fe9e5bbaaf8cd63599e02426a3a748afa549/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "04hcl445chi49kyrzbdn4r6lq4sadr4qhza0qpzpsy4yrg04ivb4";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-31f945c09f464487d139833c668d856ef43d58cc/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1m4m0n338vimmpz2p2ix6asnkmdy4x9svx1mwwgfyyvzxlba623i";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-18T21:25:50Z";
+  timestamp = "2023-01-19T20:28:29Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1g5bm80d0jpsmaxvazcyx46aggd08gbld80rgd3jzhg8c5d2z52m";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0dvisxm0snahyhvyhfl4a7s8sjrl82v1wqjdqnq1i1ppv44pi7ys";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0lmixvcwxr5nvp1gb2am13yx6s5kfzd7rypvrlxxr2166l1gn669";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "05m35rwnqr4iyk670jd44szifk2vkk67hzy068yf2rmdrls06jch";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0a887666ijx4xxjc0pnp57050gimvj3k755lymrimhla1vz8gzyq";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1hgvic21fb2rjcw707cxbknx9j196qgzaq6xx8swqwhpbfjjvfwf";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0jkb2bkggkbfyyjwckbii5lr1x0w5hw198yiyn2lndv54g2ajmc5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d8f24340860ae39c23e9917e4deda8dc3802c539/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1v8mq6481rljdk5hgyf2fc9wdw2pqfdfvzv1gpl6753n3d7jqn4q";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-06T11:48:23Z";
+  timestamp = "2023-01-07T16:25:15Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1q93zm2xlpgm7hj8q8vhidvm67inhpybzr2dkqydidpsig3pma92";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "10nxinsn2acnii6d9z5lqxzv0vji68zjd64bcv5xr46bfm7yraa6";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0m5kpxyl34wcblpbx8kzj90y7f2mx0c26dgd615vcdffg03n1j8b";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1f2h4gg1v4q60gwl54af08xiijvq7f15liv7f1q2mxfgiv3n6v7x";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0640wh354py5avc3l5qhrr8xa6qicbrkd9y5bx53r4a09k38b7d6";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1rd027j66f30ng815hxbww0mss4wif3p315wph8dgz3xh21l459r";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "071pp576nmi4rzbb3sfaaipznjmisxdf4mw5b1cyw4dsssxfj4gg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1g1c0rc4yx7g1wxxapg5az3jig8l027bb3n872jg7pdxziynxs6m";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1giadnwb6gyfh9ydyp83ib00djr16if5zhlx81mddbiillf636sb";
+      sha256 = "0sf73s0d01dx3gz9cgyn0psd9ln0fqn5i4w7lnrr8j7hrr7n6lz1";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0x17abc1c1il4rc9yia0s5jlyllih5fn9z4r5qrn6lw8md59c0zv";
+      sha256 = "0fhrcp0xk7xfn7ca64sgw0slhj7xilbr9mkng2qnfx3bqwlcb9a4";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1nqazm2fnfsf3j9sciqsyyjr8r57yafnq2s66gw1rlxj2w4cnz7i";
+      sha256 = "0msvg04vijqrj8wrl1fr1dnnnrhiz8919jk3a9vsx7ajjjq1fwi1";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b2baca32bd1a3b31b6f6ae2950a14c5bb8607cdb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0aaxszxqwn1qvnq70n742mvsa9590x8d2zz9bi25iyc82my1cm1a";
+      sha256 = "1r1w38a28hqv6j7y6hdb7qqbsm6vh7dshg3fy6alxq8gn16lv58m";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-17T19:05:30Z";
+  timestamp = "2023-01-18T21:25:50Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0wbbgbsww0yh28ixlm6ac480wxiwqx2q4sqqi9dv803pa2s42rfg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1g5bm80d0jpsmaxvazcyx46aggd08gbld80rgd3jzhg8c5d2z52m";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "13fmm4xg0kxb91af3ar63x4vdng6ih22j82dmag2b40bx39v1p3m";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0lmixvcwxr5nvp1gb2am13yx6s5kfzd7rypvrlxxr2166l1gn669";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0m0y0yja5kwmcj6aapmawwg8f6nigwxfjmw58332gwcqz4sv00yf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0a887666ijx4xxjc0pnp57050gimvj3k755lymrimhla1vz8gzyq";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4dc05d207d3790d0d554b648b45f607c50539009/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1nw0k8aps136sppsdlxw1cwd1mlfnjcan72y6407vki4c9gachfg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23c41b1e36aa71a7b8cd63440034e1bce71a0cfd/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0jkb2bkggkbfyyjwckbii5lr1x0w5hw198yiyn2lndv54g2ajmc5";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-20T13:18:32Z";
+  timestamp = "2023-01-21T14:21:39Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1g8mi3vljsbbyc53ya8w0mk0053zsl60cspvrwlmin7hs8w5zzrk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0y5m4cmqzi5sb4yp30613f115caspxymmwss9ixwvipqm8dnzvpw";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0gc1c1y66wy8bp12h6advmalsv35r2kvlcca4plbf3lk21dbglc1";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1kslfj2a99sjh17hsy0ii40rl5gj4p7dsqfvn12rw4lkxp1s2j02";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0iph63v9i46avyiksc8g3j9ycym03fsn9x1cfrg04qqh3xwxg1wc";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "15ga99ns2x1fk5jn47yz1pxm5a7f0vnwmd6y38fn3h13pbm9awaa";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0abf50099b355d67999500cb15b35b0d058b32eb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "01r533m8wa7lg3922ysgs7q9a0whxsls9za0w8vy04in189c6nr5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-08d4315330b041cba67e44c65e0fc187fef54422/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1jz3iriib2gr2f9mv68xy94qqf2fvwhmk8crbxa0piy3lyqbp11b";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-02-06T18:46:11Z";
+  timestamp = "2023-01-01T11:02:05Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "08fv8qb4615ls9h499vcsdf3fgnb3rapj91crc4h9spx96lmi746";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44159a5c23d2699d3a390e6d4889b89a0e5a5e0/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "07rmbjf786f1p88zvaxk0q596x7cykn2bbqr9pdig1iap7814lm7";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "15dq281cf2wxcy7nxaz5yw5rzp9kddwdjr5iv0ipm9m38i4jyfv5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44159a5c23d2699d3a390e6d4889b89a0e5a5e0/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1jfhmn3cpxsx0wy8fxhivmixfjrk8xrkipzaf1w1iq8aij93radf";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "16ay3j52h58by2vx2f96ar0q71dbk0ykaar8b6kd435m27xk34vx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44159a5c23d2699d3a390e6d4889b89a0e5a5e0/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "039j0cvnh1myq69yh0zbigfkvpp01pjl40vg6b50cxvr206z41rm";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ebe1b45187f56b6c024d63c55de2d520cb715639/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44159a5c23d2699d3a390e6d4889b89a0e5a5e0/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0lhzhsr8vw07s6p3429g0kzkg38s57gm3v220qckvi2w3dq21s97";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "04lbcfrf85ylmgz006nsky5c4f5p5vls5q22c6ihcmjfa3by7x8r";
+      sha256 = "08lhskmdz8ksn1ml7a4r19c681k4hw50110iiw2dynq1dqqy94w9";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "098px38c3mnnpkyh94845a34ilvdmn2lb44kbasiqgddz7vwqs67";
+      sha256 = "1bhz8g641jvns185qaabiy4cvg97zrz0x2rva08wnn89fn2r3nvg";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0xbshkmminid4h2dyx21i1317d0dg14gi413i946wjiqvp4wxs92";
+      sha256 = "02b502bc1fs78fv93cx5g4sl3rqdmvksrazd8q1n1cqdka18vmsa";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1zvz3lfkq2w1skqai57wr1vk06ypz2y6blzk24k33rry16g6szv1";
+      sha256 = "0ngdhv8assjhiny3iwq1gickclbd8pg8w7ym08llg6l14zsp8hkx";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2023-01-07T16:25:15Z";
+  timestamp = "2023-01-10T21:29:58Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "08lhskmdz8ksn1ml7a4r19c681k4hw50110iiw2dynq1dqqy94w9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1p0mpdgs501afc3sha67yccdc1p50y3f2a895vg73ag977vkkv52";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1bhz8g641jvns185qaabiy4cvg97zrz0x2rva08wnn89fn2r3nvg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "15n35r85phbygypf7rpcbp92kc98b88cs8332swdam2yn9r52cyx";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "02b502bc1fs78fv93cx5g4sl3rqdmvksrazd8q1n1cqdka18vmsa";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0l16yrh9sjddgjlm9g5mgx665jbh74ccpvfvrpm8kafylly2sam4";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a44aa13cfc23491ba32aaedc093e9488c1a6db43/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0ngdhv8assjhiny3iwq1gickclbd8pg8w7ym08llg6l14zsp8hkx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2ff99025abade470a795724c10648c800a41025e/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1740k0v3vhdm6sysak6nkacdbxnsrf7yxmk30p4nhlnp3szw9fsx";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "null";
+  timestamp = "2023-01-06T11:48:23Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/null/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1q93zm2xlpgm7hj8q8vhidvm67inhpybzr2dkqydidpsig3pma92";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/null/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0m5kpxyl34wcblpbx8kzj90y7f2mx0c26dgd615vcdffg03n1j8b";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/null/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0640wh354py5avc3l5qhrr8xa6qicbrkd9y5bx53r4a09k38b7d6";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/null/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f959af5e19c31ad05f6841fd5c40bd458b092288/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "071pp576nmi4rzbb3sfaaipznjmisxdf4mw5b1cyw4dsssxfj4gg";
     };
   };
 }

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -19,6 +19,11 @@ latest_release_json="$(curl -s "$GITHUB_API_URL" | jq "$release_filter .[0]")"
 tag_name="$(echo $latest_release_json | jq -r .tag_name)"
 timestamp="$(echo $latest_release_json | jq -r .created_at)"
 
+if [[ "$timestamp" == null ]];then
+    echo "Sad month, no build :("
+    exit 0
+fi
+
 get_url() {
     declare arch="$1"
     echo "https://github.com/foundry-rs/foundry/releases/download/${tag_name}/foundry_nightly_${arch}.tar.gz"


### PR DESCRIPTION
1 This also rebased main branch
2. I had an idea that maybe two branches can have their own releases.nix (releases-nightly.nix & releases-monthly.nix) but somehow default.nix can choose based on some condition (well, then it's impure I guess :(.. )