### PR TITLE
add support for foundry-zksync

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,12 @@
         };
 
         apps.default = apps.forge;
-        defaultPackage = foundry-bin;
+        defaultPackage = foundry-bin.foundry;
 
         devShell = pkgs.mkShell {
           buildInputs = [
-            foundry-bin
+            foundry-bin.foundry
+            foundry-bin.foundry-zksync
           ];
         };
       }

--- a/foundry-bin/releases-zksync.nix
+++ b/foundry-bin/releases-zksync.nix
@@ -1,0 +1,23 @@
+{
+  version = "nightly-dbb13e7f1ffb9f74a2d1b87a7188fcb66dfb36e5";
+  timestamp = "2024-10-04T14:11:53Z";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/matter-labs/foundry-zksync/releases/download/nightly-dbb13e7f1ffb9f74a2d1b87a7188fcb66dfb36e5/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0sysb9yxkcdcj5zg9agk3aq04y1k5bdl5rbxqknm2plsm3cxg9y1";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/matter-labs/foundry-zksync/releases/download/nightly-dbb13e7f1ffb9f74a2d1b87a7188fcb66dfb36e5/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1rlw8aq14a1wdd3gjli4fgv282i96qh0cm1cljm3gsap9x8816fy";
+    }; 
+    "x86_64-darwin" = {
+      url = "https://github.com/matter-labs/foundry-zksync/releases/download/nightly-dbb13e7f1ffb9f74a2d1b87a7188fcb66dfb36e5/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1rccyi549cdv9p41d7lbd0m7ddrmdn6gp2g12f7ixajarm8nhq97";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/matter-labs/foundry-zksync/releases/download/nightly-dbb13e7f1ffb9f74a2d1b87a7188fcb66dfb36e5/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "12wb0d6j3rxmv6r9p22my5jfwxyg32v7h39cd08yxxh6b1f8ncil";
+    };
+  };
+}

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.0.0";
+  version = "nightly-f089dff1c6c24d1ddf43c7cbefee46ea0197c88f";
   timestamp = "2024-10-05T16:14:48Z";
 
   sources = {


### PR DESCRIPTION
Implements #36.

This is a draft implementation.

This is NOT SAFE to merge as it is backwards incompatible - anyone using this flake as-is will have to update `foundry-bin` to `foundry-bin.foundry` and `foundry-bin.foundry-zksync`.

The libusb1 stuff is also something I'm uncertain of - I haven't tested it on linux yet, but at least on an M1 MacOS machine it works fine.

If the general approach is acceptable, I will update this to provide `foundry-bin` and `foundry-zksync-bin`, instead of making the outputs a breaking change.

I will also likely clean up default.nix a bit - it's a little too generalized imo, and we really don't need the commonBins/foundryBins split - it's not like there are 10 more variants of foundry out there.

Happy to hear feedback and adjust accordingly