### PR TITLE
fix(flake): move from defaultPackage to packages.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
         };
 
         apps.default = apps.forge;
-        defaultPackage = foundry-bin;
+        packages.default = foundry-bin;
 
         devShell = pkgs.mkShell {
           buildInputs = [


### PR DESCRIPTION
This change was made several nix versions ago, `defaultPackage` is deprecated.