### PR TITLE
fix: stable update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nix overlay for [foundry-rs/foundry](https://github.com/foundry-rs/foundry/) (including `forge`, `cast`, `anvil` and `chisel`)
 
-This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release, which are pruned from upstream regularly. We also maintain a `stable` branch for the latest stable release, and a `monthly` branch for permanent nightlies that are not pruned.
+This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release, which are pruned from upstream regularly. We also maintain a `stable` branch for the latest stable release that are not pruned.
 
 ## Usage: Showing off nix
 
@@ -43,7 +43,7 @@ Make a `flake.nix` in your solidity project directory:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
-    foundry.url = "github:shazow/foundry.nix/monthly"; # Use monthly branch for permanent releases
+    foundry.url = "github:shazow/foundry.nix/stable"; # Use stable branch for permanent releases
   };
 
   outputs = { self, nixpkgs, utils, foundry }:

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-04T22:41:18Z";
+  timestamp = "2025-04-06T10:18:36Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "17ccgbr3i86rj8i95j72fnbxjc0swmmb3qgyibkn429y3sv1k3kz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1g66s0yfkhmqss099wz5h3l97psq6pjf66s8pxkm0pisfbc7kf30";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "12xiy2slw9y3g84gjvp9layc4svlj6sg876rdlklxj112wrhwffd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1rsi0x8kdvv0ha1va591956dh26w6a07di8a8kzpbghp1ggh31cq";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "12g65dhih7kp6k9sx4jac06gh27ly0m3dl8hvl3227qapbzbaadg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "01d7racb2sf1yv0sd9hmd012xpjq9jp7bgqr8cmgzjh6wxy9ppji";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "07q91ka2br3idyzzns2hvlld4b05pbf4milacpkfzyq42wdgl69s";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "02fv831i0h24vcjbl6bf6z6zsj8l0z30m5f1d3x9cly2xps3lwl3";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-28T19:14:06Z";
+  timestamp = "2025-04-01T02:01:55Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "07k4s8jbla4ph30lml50ylrv9pk401355xx53sbd7iqn2hinn5pq";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "195qdv3m5xq6fmkb22cw8dchqpfdna0g87cq1fiymf243rf4c71v";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "15r1awr476k3b8yx9lfdcgpvby4rh1y985wgajw916ddz7b2i50s";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0n83k09snxg13f8q1k6p9vh578k54ssaxg9pkl5hd18np3106z20";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0zmqpdf9pdy931i9p5j6xnnz2f904c8kjhlb6qvc4q2mc751f1dl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0991k8fj4hvqb8sj8ad1vw10a3x1ayjj8wpdhkzgp0mx8cj050wk";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1yq45q7s6hp4cizswap25c91n1vy3j6fig9sz1p3v1a7lkcaqmfm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1llzani4wn9wxb79amlzznmrmb3g09ba2rjy7ivxnbc3nkf8wx6p";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-07T14:11:27Z";
+  timestamp = "2025-03-08T16:52:09Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0gaxa7rqznp4znhhlac90l9ykmdlmwvff7cq63vqzpnyvjxsy5v5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "12yq9rzb2367bkzkymqlcsgqvgm8a3gwdkkdmgvvrfg9ni4mvyji";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0n3xq3r1g8362yvyb9zay90mpi1f985pwc0bxh7bsch2q1qb54ig";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1azl2wcfz28a37r14i1s51p4lb7gxpayfx0n0n91cz2g0w7czy27";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "05dfkqgd4533n5n77r9iklziq4dkdv2qdcfnx05llhv831jfx707";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0ax94q0canxcadjn47p56kpswvsvam6fymlrirkpnj1whdvvk9pf";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0piqh4fgpxhr54j2sxnp8sqvyrybycqhzx3bndjx85fc86apmm5k";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1jxksxs60wnspamzwhh5s3jwj596j7n4ds0d7g65sgcjrsf1psza";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-13T18:11:26Z";
+  timestamp = "2025-03-14T15:29:21Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "04z0zap2g0sch8l99lcrgd6ydasrk2s3ff47r1hh535x5hd4lyka";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1zh8ih559yq1ccfia571k91q74yk3db8hrjqj57si9zdm42lr29h";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "10jv6a1ai2fisms3l6la8b14j7cdvdavb0wz4y66rx4pcn9cjz6d";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "12qlm13wbzsvnsh4xf31kfmxdy8wpz3wz0qac3jgj2sh4qjpayw3";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1q9f7a86lhv4h4b8vzm7ljq5a8w9xibmlf6sr5jvlyz2nacx1d4v";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "146xj4sg63kp6m5lljg15mrlh5w4dbyz6wriv24d3d9m4dic3yyv";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0wh7dh9vmrz58aib8b1w2cmb6dk0mmxqn9axp2ml7ydazh5sx4m3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1q4mlhxa9r2hnaf8h4n5wrqcx10mw9vj4zb8kmlsmkf8m25vq85g";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-10T20:49:39Z";
+  timestamp = "2025-03-12T04:09:16Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "19xdbmmcz1aizjnhl0m2yg8dbpdff0qggs2bnw4fxljdacc737fh";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0rp0sd62cg8629lkqa6ck6xqr73vdiwwxmpkj1ifci8z3mz142pg";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0080hq14b1l3hs45qgj4sspqvknv209cf9px4m59a1mr42m9xi8c";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0y3qkc4i9xykaqai8svz1g6aqrik5c5lss9a22yz5iz722x1z859";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1vpdbld2vs04l1ijb37587p3m4vpcx5krx3c2vs8ypp8p4c5ml1q";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1gg9g7bk00fdvffrbx2innmdgmp4hifixgkd7zl2jfcm70z3kf5j";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0y7hny90y511xm8aqf98934202m1pgn43cjy25f7w8fsr7m2aknf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0ryadl0pz8ggdbvv09g8xg1fkk9jpahw267i4sf86xwpcs4kclj2";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-09T04:48:07Z";
+  timestamp = "2025-04-09T15:51:17Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "08dpxvs9vm99ilki8iq5idw6rp2q9jqi54k6a7sc7s76ni094i9f";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1g3wpdbnvnykrisp4pnr3cbs6s749f78wpq19bs3cbnhhq0r7whw";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0wk3mjy04rfrmnsphm2yhl4k247xijzrzr0v0wnlkbf9cdmxbjqx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0pdx0f4bv87hv8j8n8gkjv2pl3zbrn02baw1pldbvljwvrw1rg1y";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "01nk0ggr729lsdndsvd0f6ppd4xq1iqhqggk890y9pdfxp0zf0d8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1qc98gsrm3wlpddvkh6nsbb5cqa9xvvfvh6bj3bj100amkfx3lj5";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1vqzpjq1sz9j79cf2hhbibi86bs7cqklm616j5w72z9f479dpkhf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0pggdzpnc203x1z8mlnxix5f71rm2pfg6r8mc554akwnriyqdyy4";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-01T21:05:10Z";
+  timestamp = "2025-03-02T10:38:57Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1akgjbj8bvjpr32b9z22hn3w5dw84xbzmfkyqd2k6cpliqrcabn9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0xy99l8nr1h76zw0rmj35i5pdq3b7ln8rjh3415g5d3gcg9p0ns8";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "00ii9pjs58vbxsikwpyab8q0pyb68y7rvgqq3kz03xswzsaqlplr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1fpvp4dzrvai280ijj2ss2j6b2v0vngnk37n0inv4vdsc0hycn2f";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "01bmnh3mmzzqczbwdg2pr1l6ffzyb73bw3i6na05lm03xk5m62vg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0zi26i6p56b1wanim0nwwkdsi7akfsy3pgygzy3wxqnmsrr52pdj";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "09rzrpfk5p9kjxdvc64j1g8yrpdmxd74rwjwsmkiqsp1fbciimp6";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "02zc1jzpfkabyh1avjasry25w3lpx670m34a855rahic4y0v9qsa";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0230byzj04b4pkn5cnmm70jh30akdrcrn01fzmkf9wkdjsbgqnmq";
+      sha256 = "0gkizbnxz4l0l6h6llypc17c7a53bjf9xga7yrr8r9kca7ak42mf";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1csniqrr88h4g5i7wy3j0bgwwid2sgpdqskdrs78p5hq72ndbszz";
+      sha256 = "1wxbyv6sjnj4mcn34ars5y8hv1gj3pm2vj3cfyrdqf6r8n2kwxrw";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "01bxhyfwxsk1a83yraljvxcnfi2f3q5145h616lk3wkpky2gi6ha";
+      sha256 = "1la67n3373vj1clfwdrg52q3gdmnkvfs2a84pvn04fzlhmqk0p39";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1bgvyk053bs22gyy7yksw353x82pf2c6zx38fqc4347167bcqfrq";
+      sha256 = "12z4cw3zsswdylgy148d3ky80w61c11g043w37s9x9z9b9nxsvxv";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-04T15:57:22Z";
+  timestamp = "2025-03-05T19:52:25Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0kaq91dplz4x46yhqqfxv1jgm6qfyd5gavy9dqvr30zchbxwhmdm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "19l9a8mb41qzsklxwgv9dszxfw2dzyi1gd4ab48s27v8c3iahhvr";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1kv4vammm9dhpcpm6i5jb9kw0zhspxcji339y5h9acqi1x8lsjk8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "12pzsy9sczhz5axz2nvv7phvlydnwfqlpff89d03pyirj7s7r374";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0xcx4z6bw21kf2jz1ppgahhwqyg2v165n9kjxxgkbxb0ngdsxajg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0hdp398f4fp66qplbg1ypfamppxqliqfx069cdl5810kn2kmkxi3";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0lwkd1ic5isca15nk6rg10nyjaqp6vpmik70kjk044a3qdfny23n";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1nkfrbc473qp7jj01a4ravyqhg9vjmjrgg7fiky4jghx574l490i";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-14T16:45:38Z";
+  timestamp = "2025-02-17T16:41:46Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0gkizbnxz4l0l6h6llypc17c7a53bjf9xga7yrr8r9kca7ak42mf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0an55d7148p04bajgxp641k4yb42alxhpvpgfa0jwscdjij3hhfh";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1wxbyv6sjnj4mcn34ars5y8hv1gj3pm2vj3cfyrdqf6r8n2kwxrw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1n0ga8chkd7brmin91d32ynspf935s1caxdz8x4p5iw6lf0042aq";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1la67n3373vj1clfwdrg52q3gdmnkvfs2a84pvn04fzlhmqk0p39";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "044yyb7py04d8bbj6wwkcyjna2xaac3r3i356b9vg2id0h0nwyxk";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "12z4cw3zsswdylgy148d3ky80w61c11g043w37s9x9z9b9nxsvxv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0ri48im43gszv1rl2hg46gv8ilql8bx1ajc5sxrsycvq008nj9aw";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-02T13:02:55Z";
+  timestamp = "2025-04-03T09:29:33Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "12wsjkqqqaxkzasmhcs98lig8cklkfdi895bbcf723kyf7hz4nil";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "12g027sc12sqiyj4fr9872mvykl1x14d18jgb40v01dwhb3lg189";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1hayv15kazygh93apm81w36zwmgsf7cyiqp35dj095c6lccv9xw6";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0x7gi90xw4wzlyx09933lacqn9n9690pjqwhbq0k6iic5k2qrr4z";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "03n1lylnhw9c4qigwv6s8f3ykvk9hzbygk055b3q4i9an9jmvhq9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0xdyh8gzpd8am1cvdasnjnasfhxl6df4bs9kl37fsfwkncz9r438";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0bb3k371nkb9vb1414v2bngq5n36p901kfa6w4w391gg2q8rp93k";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "06nq66cbyjfaxfj6hkvrkyb35a3d6j38a918balkrb5nc36nvwk1";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-03T09:29:33Z";
+  timestamp = "2025-04-04T22:41:18Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "12g027sc12sqiyj4fr9872mvykl1x14d18jgb40v01dwhb3lg189";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1nb1m2qfdn5vzay0gi7kmadjkr5br1qgxl9a3ycaza6nkgb21gnq";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0x7gi90xw4wzlyx09933lacqn9n9690pjqwhbq0k6iic5k2qrr4z";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "192jx20dmbblk5c590jvf32hypv0a6mkd2k9r01dil86r1qg1098";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0xdyh8gzpd8am1cvdasnjnasfhxl6df4bs9kl37fsfwkncz9r438";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1058x8abx7w1iwfrg4wzf46dlmyg0dp9qqrb29z2lprhgpi20vjk";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-58cae24dff2876f09433386b071c7bdb3ddafa50/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "06nq66cbyjfaxfj6hkvrkyb35a3d6j38a918balkrb5nc36nvwk1";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "07w50zngnb2vhs2ijh2hqhrf6gwclgpjlx03wi6x7yid5plwjki5";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0gffckwkmx38fq4fnwsdbl7fdxshsp681azzfmacsxnh3aryarc3";
+      sha256 = "1jkrflpi4sky3xx9gxw4baqw45blci0pn9lc260lnvglpxk83d0h";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0774scj1hiwpxr6vqr8l849yb5mqbq02ksjp5a4dmh10m959n3gd";
+      sha256 = "11sjazw3j62npqaxlfy304r6lvyq17w52v38ljzba0qj3dcf89s9";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1affp3ggavhpqjsgf7cla21l1b57wj38dygahpiccqzk384z3bfb";
+      sha256 = "1383nl755lizs3y3zprkadzvrjz44239zvnim5gy8r0wvqnyj62r";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1higm4xm87fda1hd5glrjhk03680aayiqifgvqq4kgbr1k1dwxg0";
+      sha256 = "1j7xibnaj39j49lqjy2m2r2d8nma06i5cq9pa2ddq2fg4w8rm6z7";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-23T16:01:04Z";
+  timestamp = "2025-03-24T17:39:32Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "18fwxzwvlwl5i2n3hg8dccv8gd9lvgdl2hhvbs61bn7k2n80zjkz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0ihkhhkqibacrzbkysdqm8fir6if3m9cs8bk2d0p00bssni5wfdn";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "13nh9jxafqds3ld1vsnyjnimwvw5c0x202lffngg8wa72q6897c1";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "11fqlym7zjclnsky4185khs2sa4v6zjm4hvadlf095zmvkdpcx8b";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1mqc17v5zrqbnhnjzdcrvwllla72n7ram106br428px3yg9k2kl8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "07x4s37s1mkcrw0q3xs7fwccy8zd8wycq69w1jyd1sf7mral3cdk";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1ps4c791157laxkcmng5p64lwcpikfksffnk4msyr93h3vxv2qig";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0annwhf847adqvv8p81vfdsdqab5pb76c4kg185m5jqiam4vjm54";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-26T12:58:24Z";
+  timestamp = "2025-03-27T18:41:46Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1py0k1c08wf2pg4l32mxdpgh39x65fk91qk4ffg685d4r319gf48";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "12gy26x0s8p45nb985zsd5fvnn9sqdqpnydzsri04xz5m9yknakk";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1afdqj6k8fzwlrq7l3fjlryfq91q0b208ag9w9h946d9r13sh5kn";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "18gkzhk4jlpbdxq6fa86hk2b0866hq4jsil6frkb5h8f9p6rzzpv";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1nsvz6317qy1yzq1wlm3j05k43wjhi8xq2ac348061lbm8vxmqmy";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "04cy422ja6gj9ss16xfw71flkm0fpym6d5r6xa1ckxp7misq24m9";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1baacf1p6853vksxklkhc5d7qy0jhiyyjnd9gvrf80c84l75m0y7";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "168faf68p5b3782zhin2d3iz0m4m8qkc7n3fmg40zxwzbp0xlg7m";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-02T10:38:57Z";
+  timestamp = "2025-03-03T15:37:32Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0xy99l8nr1h76zw0rmj35i5pdq3b7ln8rjh3415g5d3gcg9p0ns8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "009839dg90y57a65c3rcxxq0xja2dh053xlhyjqk3zgsbxqim1rr";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1fpvp4dzrvai280ijj2ss2j6b2v0vngnk37n0inv4vdsc0hycn2f";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0vmylxnsm632hj7ldkcjrck2npd4nfqbf1zhmkaywcvw10lfpnv9";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0zi26i6p56b1wanim0nwwkdsi7akfsy3pgygzy3wxqnmsrr52pdj";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0mn11vd0kxyr482nazr3ixp2bij6qdh5r7rjg9v5bz6j296wrcp3";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c56a65b9b508429d1a856c7e46140c0472b08e45/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "02zc1jzpfkabyh1avjasry25w3lpx670m34a855rahic4y0v9qsa";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1frahx7751w0b5p7vsknlchskxly3yac1b6090qdm36m16bkka5a";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-24T17:39:32Z";
+  timestamp = "2025-03-25T21:17:03Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0ihkhhkqibacrzbkysdqm8fir6if3m9cs8bk2d0p00bssni5wfdn";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1x5yard2dn90yqmvnlks78f0rd63z2976yaaz62i5m99d6hl5i9j";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "11fqlym7zjclnsky4185khs2sa4v6zjm4hvadlf095zmvkdpcx8b";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "03g8nd4cka2d4ar8mwal4zp7wx0yjvc31ani7c36xnsdfh95krrc";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "07x4s37s1mkcrw0q3xs7fwccy8zd8wycq69w1jyd1sf7mral3cdk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "08zcskd92wwfh3glxwaibagfsnf95dwdi07cj09z32szyxb43xlm";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e0f87ad31d929abcf7f0eb96952e1805dc9d2c22/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0annwhf847adqvv8p81vfdsdqab5pb76c4kg185m5jqiam4vjm54";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1kbb1cniql0a7i2mvi33pllr84xbqxbid7f4i3nsix1yn3na3537";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-03T15:37:32Z";
+  timestamp = "2025-03-04T15:57:22Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "009839dg90y57a65c3rcxxq0xja2dh053xlhyjqk3zgsbxqim1rr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0kaq91dplz4x46yhqqfxv1jgm6qfyd5gavy9dqvr30zchbxwhmdm";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0vmylxnsm632hj7ldkcjrck2npd4nfqbf1zhmkaywcvw10lfpnv9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1kv4vammm9dhpcpm6i5jb9kw0zhspxcji339y5h9acqi1x8lsjk8";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0mn11vd0kxyr482nazr3ixp2bij6qdh5r7rjg9v5bz6j296wrcp3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0xcx4z6bw21kf2jz1ppgahhwqyg2v165n9kjxxgkbxb0ngdsxajg";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-4e6a85995426aa655d52c10d94133bef5849d7bc/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1frahx7751w0b5p7vsknlchskxly3yac1b6090qdm36m16bkka5a";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-d3704ee2bb6d2565ac746ed3951666932b287487/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0lwkd1ic5isca15nk6rg10nyjaqp6vpmik70kjk044a3qdfny23n";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-18T16:25:33Z";
+  timestamp = "2025-02-19T07:34:07Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1sk1dx9w70qmrkdwm8bw8vg1hl1p3y0lwk2b5mb8hdvaixzy98ld";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "07zhljdyxzd76znv0m9rc4713bfnksfis0iydvxmcnda3vlvww1y";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "15hs1pcsb94aghqjdbspaiw3hyyf0181w9j2rlc768rr0kpldi0m";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "15ilgyyd9dpxwy4s1b0zxrkihabbzjlwc7b7vjjmvh820skcy2yv";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0c3n2w6gypmdz7zdd2x8v86gk8pkx6nwq2inw5zsavflh52hn9xg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "16gj5v9dvc7zl2xxm69liy5sx0m3x7xh89wz7rgx06p0n56jazcp";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1mgd0j5ca4m5a5h6m2813lpy0178d0lp9fh4bg2y9sd7zgia3vvk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0m2g8qis0yimlnfzhd3n379kjndp6hgzrz97bqdhmr9z4b49i4b8";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-18T17:24:30Z";
+  timestamp = "2025-04-20T11:03:39Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "05qsl9plah6gzr8qa27imz89xszd2863bba4wngf1bj3x2406rkc";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1ae64e38a1c69bda45343947875f7c86bad00038/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0c6c0aspi6l1wzq3pzs4nsm780n7nl5m30df1fg3zvvrss4r23mx";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1k042abmb54y29am7nkhqq5ksvil6x9dbvlm61gs8hx19vvixzgf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1ae64e38a1c69bda45343947875f7c86bad00038/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0c6jd1a6aszxi52dky3r28flgj34hhqjiw5gpqplcgl8wnjm0azz";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "119fiqisi8zmd2vq1kwj5ygs7nazvm1h22xl2sirwbj9qpgc6ncf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1ae64e38a1c69bda45343947875f7c86bad00038/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "15jkbzhma5a486z6zqna4zw4fvz1g88rm4fwq87v450dgfjva1yn";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1369bl47ri0r8jha8vai035cmsqp9shp87x49j2smfwmgldfkzzz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1ae64e38a1c69bda45343947875f7c86bad00038/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1rqm4dh152bzan5hm8lllnmfyr59ypwqjfnqwynmfpzyd0a3bfmy";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-08T16:52:09Z";
+  timestamp = "2025-03-09T10:42:26Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "12yq9rzb2367bkzkymqlcsgqvgm8a3gwdkkdmgvvrfg9ni4mvyji";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0c6cym10vqsq4cl9nyqy4rxz2bixxanp38xi5r5g843qcw6sxa3k";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1azl2wcfz28a37r14i1s51p4lb7gxpayfx0n0n91cz2g0w7czy27";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0hri1g4572vjhhs19jjgglw288hrraj70z58391gvfia6xcy3kc5";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0ax94q0canxcadjn47p56kpswvsvam6fymlrirkpnj1whdvvk9pf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "00w5kqv2h527xacjjzrwq2qx6kcia0xm758q89q6scc33lz2j5si";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-b384c96d318414f9d3b72c11ce839f8e7450709f/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1jxksxs60wnspamzwhh5s3jwj596j7n4ds0d7g65sgcjrsf1psza";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1snanzxcxrg6bn3wyrqh03l6952rpypfmz73nf3v2nc5rfivg79n";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-05T19:52:25Z";
+  timestamp = "2025-03-06T08:10:27Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "19l9a8mb41qzsklxwgv9dszxfw2dzyi1gd4ab48s27v8c3iahhvr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "18ap3i22md7pawkj62isl919bz3jjj6s9y0izcylqz36h40fcfmi";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "12pzsy9sczhz5axz2nvv7phvlydnwfqlpff89d03pyirj7s7r374";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1gipwznpjk7w9pfa5qmw5dzv5s8bhy1w60851sg1p6h3kw57s2z5";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0hdp398f4fp66qplbg1ypfamppxqliqfx069cdl5810kn2kmkxi3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0lz0ql82ci23njqh54yqrrxq4i5d488h6gvfprckd8jmj8a8575c";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-71e8e0f2d09ab8d8c8d8a2daa46c1c38ed80bd4b/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1nkfrbc473qp7jj01a4ravyqhg9vjmjrgg7fiky4jghx574l490i";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "057zz8nv64abm5g4w59kybkgd23lx81c5yf97z2282pgs9m3cy4l";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-26T16:05:48Z";
+  timestamp = "2025-02-27T18:52:36Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "02msajfrsf241kp9npc9gb1bc74838rsl5rcn8rdz1rmg0byqa65";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "13k45vapyh290i8bd3pj4hj42s08p29zbiq1lychbj73a6qhj4g8";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "02dl0i8h3f7rwqpg5qqv9fp3f3xz9amb3k3kyjbp1cwjcs2b120g";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1p41ncsdzaw6zk80rxwsgdyx67r65rdjyznjkqd1hylkvyq08a75";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0w108jhy4hcq52j4lg4041hrdc96kakfx5sb6ppr7jaax3m87cgd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "16jz4qxz97hdsfwivnxhxv7gqmh5sp3bbpv554d1w02knvfzfh3v";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "157v0d95gs9rcvlvyq7qwpcbdawx3rg6gwgqw05hr3lrhhdv5iw3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1f74s1yyph5y53nr3gqqr3gz4ryh7m3iryrj4h92pm28w0cypqqw";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-09T10:42:26Z";
+  timestamp = "2025-03-10T20:49:39Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0c6cym10vqsq4cl9nyqy4rxz2bixxanp38xi5r5g843qcw6sxa3k";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "19xdbmmcz1aizjnhl0m2yg8dbpdff0qggs2bnw4fxljdacc737fh";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0hri1g4572vjhhs19jjgglw288hrraj70z58391gvfia6xcy3kc5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0080hq14b1l3hs45qgj4sspqvknv209cf9px4m59a1mr42m9xi8c";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "00w5kqv2h527xacjjzrwq2qx6kcia0xm758q89q6scc33lz2j5si";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1vpdbld2vs04l1ijb37587p3m4vpcx5krx3c2vs8ypp8p4c5ml1q";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c627603991d7567e1c9eef2fce36c46206301d82/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1snanzxcxrg6bn3wyrqh03l6952rpypfmz73nf3v2nc5rfivg79n";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3c048be05726218c405d5d4deec4d3f1ab515f6f/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0y7hny90y511xm8aqf98934202m1pgn43cjy25f7w8fsr7m2aknf";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-20T17:34:07Z";
+  timestamp = "2025-02-23T19:10:05Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1jkrflpi4sky3xx9gxw4baqw45blci0pn9lc260lnvglpxk83d0h";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "189q5flm7k5liqs95wjj41dqmj1lrbjjq84ixixxljkpdridpcdk";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "11sjazw3j62npqaxlfy304r6lvyq17w52v38ljzba0qj3dcf89s9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1pgg5z59fknibx7pdc277lq58bmn83qg85cbqdkyyzpah1wvg1yy";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1383nl755lizs3y3zprkadzvrjz44239zvnim5gy8r0wvqnyj62r";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1284dakw79x0gq72wcl2i4ka5x0dyak6rc93r8ayl4askxm8hvpj";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1j7xibnaj39j49lqjy2m2r2d8nma06i5cq9pa2ddq2fg4w8rm6z7";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "14i3qkx44pjca06s5x4anadlvxd2a69sbahz0jr5cv5k12y1ijrk";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-16T08:15:03Z";
+  timestamp = "2025-03-15T20:17:25Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0wzrsq879r74jxafp3ggjy5k0ss56sxa4c2dcq0xq4fvbkj93af5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1vagkrgmfbwprjw4jr79cjwnkq3wa2wva6sg789rf7d3mlwp288s";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1fgfg7wj7799pqm7d4xb93bq0mqrxc3958chl4mfm04fdblsws15";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1c8lhnk3jili1rnb90bxqmgxbp2wzaavddlc36v4c31iyig865j2";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1v1vc7nh6gzlfg3jrmf4sxxxw8ij8zk8qhwz0jb2z67rv8aynmyq";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1jbkmvx9044981jq6x026whvi1p957h1bh98cprd6p8cdr3bw4ii";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1barrlazq9q4q6w6q5w8j7ip675pvrqiwgwcmk5vm52p83hwflmk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "15dki62pq1rnbzlzlm6fkfapxfj20iw84h298qsdaan6wgjrqsqz";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-06T08:10:27Z";
+  timestamp = "2025-03-07T14:11:27Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "18ap3i22md7pawkj62isl919bz3jjj6s9y0izcylqz36h40fcfmi";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0gaxa7rqznp4znhhlac90l9ykmdlmwvff7cq63vqzpnyvjxsy5v5";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1gipwznpjk7w9pfa5qmw5dzv5s8bhy1w60851sg1p6h3kw57s2z5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0n3xq3r1g8362yvyb9zay90mpi1f985pwc0bxh7bsch2q1qb54ig";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0lz0ql82ci23njqh54yqrrxq4i5d488h6gvfprckd8jmj8a8575c";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "05dfkqgd4533n5n77r9iklziq4dkdv2qdcfnx05llhv831jfx707";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-54af8693b8fcc7a3f65136c1188e89661155955d/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "057zz8nv64abm5g4w59kybkgd23lx81c5yf97z2282pgs9m3cy4l";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-23191fbeccfcf901f7c28590cb962d9693373c21/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0piqh4fgpxhr54j2sxnp8sqvyrybycqhzx3bndjx85fc86apmm5k";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-25T16:15:31Z";
+  timestamp = "2025-02-26T16:05:48Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0kq2h9axwrgkimi7slw6p3wnywg3xg1b6ypp05agfl0s8j8ddnqs";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "02msajfrsf241kp9npc9gb1bc74838rsl5rcn8rdz1rmg0byqa65";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0d8w8lwjjv86198mahcirhvs3si4b1k8i3zzw1wsn5kzh0aqx526";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "02dl0i8h3f7rwqpg5qqv9fp3f3xz9amb3k3kyjbp1cwjcs2b120g";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0fsy7bbf6dk5zy680mb4l5jnzrryp98agqhn4qw962gfk4kjj6gd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0w108jhy4hcq52j4lg4041hrdc96kakfx5sb6ppr7jaax3m87cgd";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1ihjwj9zrmz8alqc6zkiml675avls6zm95c0k4243ah0xhmrk9qr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-2fe902962cd76846f3fb02c24576789ee82b35d5/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "157v0d95gs9rcvlvyq7qwpcbdawx3rg6gwgqw05hr3lrhhdv5iw3";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-20T03:18:41Z";
+  timestamp = "2025-03-21T05:15:43Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "19i88l8cgxj634lr9cz9jx41gz1bl1x5kdbyk89g4zc3xl8bsdyv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1zh49cfps7byn7hldlpy27hcdkbqq81ragrl41nl032m1d1wd87v";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "16fzvqlvgs6qba9fbd09m5a407z4h0vza03sgiv9921pl7jmm26f";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "06axxcd0c392v6k4vjawhja24qwi3wyqrzr9cy34lm7zajv42xgv";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0b1kxj7nfrkqx1fclq84kzjg9vd1nard5rj03m4sawzdbprn1xl4";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1xrg5i40v0d1d4brgx3xpixlak5y4lw15k8i5hlfyd87rc2vp3g5";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "09zkzdp43gbs7k89dndcd8hhc78n4lpgqcdvdlq1q9fx4xg1w4vl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "182bl61rgws70c94llkrscyfqphy4mmq6gvlygpisspxxvzlc826";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0dd2v84bvd7l467kd9jbyb3hj4zp164arvbh81ci8bxp6p2x96li";
+      sha256 = "0gffckwkmx38fq4fnwsdbl7fdxshsp681azzfmacsxnh3aryarc3";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0idqh85chdijz0ncch8yzxdd9pyc1jx9qfinq4i1iadhr2ddxkli";
+      sha256 = "0774scj1hiwpxr6vqr8l849yb5mqbq02ksjp5a4dmh10m959n3gd";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "15kagwwyl1143irkmbj8b17pqbyhlwlcvm3kiqpphd74wmvhysfx";
+      sha256 = "1affp3ggavhpqjsgf7cla21l1b57wj38dygahpiccqzk384z3bfb";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1q83k5lar0xd8l7i369zz11qxgihb46a47rxxc4d88879mv9hy4w";
+      sha256 = "1higm4xm87fda1hd5glrjhk03680aayiqifgvqq4kgbr1k1dwxg0";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1nb1m2qfdn5vzay0gi7kmadjkr5br1qgxl9a3ycaza6nkgb21gnq";
+      sha256 = "17ccgbr3i86rj8i95j72fnbxjc0swmmb3qgyibkn429y3sv1k3kz";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "192jx20dmbblk5c590jvf32hypv0a6mkd2k9r01dil86r1qg1098";
+      sha256 = "12xiy2slw9y3g84gjvp9layc4svlj6sg876rdlklxj112wrhwffd";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1058x8abx7w1iwfrg4wzf46dlmyg0dp9qqrb29z2lprhgpi20vjk";
+      sha256 = "12g65dhih7kp6k9sx4jac06gh27ly0m3dl8hvl3227qapbzbaadg";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-138090194e109b62510e5e23058d01f6d0d6f924/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "07w50zngnb2vhs2ijh2hqhrf6gwclgpjlx03wi6x7yid5plwjki5";
+      sha256 = "07q91ka2br3idyzzns2hvlld4b05pbf4milacpkfzyq42wdgl69s";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-25T21:17:03Z";
+  timestamp = "2025-03-26T12:58:24Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1x5yard2dn90yqmvnlks78f0rd63z2976yaaz62i5m99d6hl5i9j";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1py0k1c08wf2pg4l32mxdpgh39x65fk91qk4ffg685d4r319gf48";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "03g8nd4cka2d4ar8mwal4zp7wx0yjvc31ani7c36xnsdfh95krrc";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1afdqj6k8fzwlrq7l3fjlryfq91q0b208ag9w9h946d9r13sh5kn";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "08zcskd92wwfh3glxwaibagfsnf95dwdi07cj09z32szyxb43xlm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1nsvz6317qy1yzq1wlm3j05k43wjhi8xq2ac348061lbm8vxmqmy";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-539fd9611e213c0e72e5524b6030d00bf21c9587/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1kbb1cniql0a7i2mvi33pllr84xbqxbid7f4i3nsix1yn3na3537";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-60adcb5c3a243b739282ae8c25adecb06c8b2625/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1baacf1p6853vksxklkhc5d7qy0jhiyyjnd9gvrf80c84l75m0y7";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1cgsrps2fdh4vafn9wimlbmxgqh0z0arisxl2hm57imxpc3c8yhn";
+      sha256 = "1iiifa6r06g8gz2zmmmyskrvhlzgm766l1w81m04zh7mzssv08sd";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0cvsp0ax8nph7hf1xmki5mbyp46ypxfk2qfk5zs35p4q7mvhj5gp";
+      sha256 = "1gb3hxm6r2zz9z7p553q11q5ppkr1yk3hych6hy4kvmbwm09l8bc";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0kh039xlmky1jryllh6q63fb53fjczay0acyzriqvvrdvw2gkx2k";
+      sha256 = "0jxjwrncbgs684a2lw03rd5zawdv9fj9ij4wa8d8jzvha9jk91zn";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0nbi83gyny8vif1w7p08pddzgmn2ksc142vz7q4iqipz80vvxwm8";
+      sha256 = "10nkkylmv0kkjdym83pmdpngmvxdd1j8h7idrh8x6bvby3hcn737";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0lzrnfdbyhkzh34ajsik74l8yxiy3q532p1ffdrgwhx7z95d4ma0";
+      sha256 = "05qsl9plah6gzr8qa27imz89xszd2863bba4wngf1bj3x2406rkc";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "132398av7pa0i13sppmsglilx64ya2lnfvh65jnllkd3xn5kn37d";
+      sha256 = "1k042abmb54y29am7nkhqq5ksvil6x9dbvlm61gs8hx19vvixzgf";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0z6lgz1g15ryxjyyvln5gs52aa0rw81zlxpm1pskx6zl46ajs9an";
+      sha256 = "119fiqisi8zmd2vq1kwj5ygs7nazvm1h22xl2sirwbj9qpgc6ncf";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0lbryw9k3iya1gw55v0siknyc15xdsdzix9jzfqirr0psrkqh58i";
+      sha256 = "1369bl47ri0r8jha8vai035cmsqp9shp87x49j2smfwmgldfkzzz";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-01T02:01:55Z";
+  timestamp = "2025-04-01T21:34:38Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "195qdv3m5xq6fmkb22cw8dchqpfdna0g87cq1fiymf243rf4c71v";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0ay9jcwjhwb0160djg0a9qqhn4g6a5fphp3kr1wcwdzrqp8yhxl3";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0n83k09snxg13f8q1k6p9vh578k54ssaxg9pkl5hd18np3106z20";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "03fjm3f1v53d2a8ra0haw8pami9zc864km7chj3gbpj9dwmhsy6j";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0991k8fj4hvqb8sj8ad1vw10a3x1ayjj8wpdhkzgp0mx8cj050wk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1i5q7hqv4sv4byj5y9db4qr60mdn1khni9sa8vl2a22l9jvcmkmc";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1llzani4wn9wxb79amlzznmrmb3g09ba2rjy7ivxnbc3nkf8wx6p";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1h9czdc16fvv40vnn902zq6vlgny7rkbs57nby9kdpga976l9bgg";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-27T18:52:36Z";
+  timestamp = "2025-02-28T08:38:03Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "13k45vapyh290i8bd3pj4hj42s08p29zbiq1lychbj73a6qhj4g8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1ay2bsha24h4b69m4hdnv4f38g6vyqmcy7q407i2w2dr48rjdqir";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1p41ncsdzaw6zk80rxwsgdyx67r65rdjyznjkqd1hylkvyq08a75";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1rz4hgdhiab0adlwqljb1sbpgjd6xnwi6mdqy9xn6q5kch8y0rxs";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "16jz4qxz97hdsfwivnxhxv7gqmh5sp3bbpv554d1w02knvfzfh3v";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0bcm8grizfq1n87fas4iq34dgraqn2l8h0dc9gqv1jyja2n5v504";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-535acf42dd14060ef0dc174589f96f525b6a90a0/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1f74s1yyph5y53nr3gqqr3gz4ryh7m3iryrj4h92pm28w0cypqqw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0fzwlc4djh05zxvbwzzfq8k1w7kx94k8fa725akcdvvylj6vysp9";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-09T15:51:17Z";
+  timestamp = "2025-04-11T05:36:36Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1g3wpdbnvnykrisp4pnr3cbs6s749f78wpq19bs3cbnhhq0r7whw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0b65kx43f2qzl72vmf2z7k2sq220fiidm79ixnkfq1d5rhsribwh";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0pdx0f4bv87hv8j8n8gkjv2pl3zbrn02baw1pldbvljwvrw1rg1y";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "175vnk1b21v0bpi74izsh068ysqlmh13ld6ilm33bas4sqrq5dhm";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1qc98gsrm3wlpddvkh6nsbb5cqa9xvvfvh6bj3bj100amkfx3lj5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1dvim92p8m043jn9ph8h12xnj7vqd8i6ggwig09h1608r6nq0arv";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7825a06862b0c97a510618f5c6901eca279e4802/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0pggdzpnc203x1z8mlnxix5f71rm2pfg6r8mc554akwnriyqdyy4";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1nlij1nk6whqvfgnjppmq2p9kn9zrghxa12jqwa31krmva5i4sj3";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-27T18:41:46Z";
+  timestamp = "2025-03-28T19:14:06Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "12gy26x0s8p45nb985zsd5fvnn9sqdqpnydzsri04xz5m9yknakk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1cgsrps2fdh4vafn9wimlbmxgqh0z0arisxl2hm57imxpc3c8yhn";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "18gkzhk4jlpbdxq6fa86hk2b0866hq4jsil6frkb5h8f9p6rzzpv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0cvsp0ax8nph7hf1xmki5mbyp46ypxfk2qfk5zs35p4q7mvhj5gp";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "04cy422ja6gj9ss16xfw71flkm0fpym6d5r6xa1ckxp7misq24m9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0kh039xlmky1jryllh6q63fb53fjczay0acyzriqvvrdvw2gkx2k";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5699fab4c8917d7d0f542fc552dc88afe543ccc7/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "168faf68p5b3782zhin2d3iz0m4m8qkc7n3fmg40zxwzbp0xlg7m";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0nbi83gyny8vif1w7p08pddzgmn2ksc142vz7q4iqipz80vvxwm8";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-21T05:15:43Z";
+  timestamp = "2025-03-21T14:30:05Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1zh49cfps7byn7hldlpy27hcdkbqq81ragrl41nl032m1d1wd87v";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0bygxky9b2hf12y61ddsrsdckfvw6w1kiv09s7pb3nnic5n2f76n";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "06axxcd0c392v6k4vjawhja24qwi3wyqrzr9cy34lm7zajv42xgv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0r1ysgi92vk3jaa07p7hff9dbnqx9k0ybwa7rx5974mpqzhldjc3";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1xrg5i40v0d1d4brgx3xpixlak5y4lw15k8i5hlfyd87rc2vp3g5";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1gj02b4dw1zhkn2xha9a1bf7iznsnqw32gdmy8b4b5h6jj1fq2b7";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "182bl61rgws70c94llkrscyfqphy4mmq6gvlygpisspxxvzlc826";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "03lxg5i2c2aixwxrarhfiyqkh9f97mk4rq04r2dhx0mps44bn4hm";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-07T19:30:32Z";
+  timestamp = "2025-04-09T04:48:07Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1xvnhxcl0nxv2i0xkfr505bx4iw5mw42iamy0g3d0gi1zf2dyzj8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "08dpxvs9vm99ilki8iq5idw6rp2q9jqi54k6a7sc7s76ni094i9f";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0fx2q1b89aysri6lyzpfrzz42l57pyzh93nibiqn1fxvjmv99acg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0wk3mjy04rfrmnsphm2yhl4k247xijzrzr0v0wnlkbf9cdmxbjqx";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "17fdm3vr8iacsfls3m237l6zdzphrlxcd7ax8gxw30nd8ypzb2ry";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "01nk0ggr729lsdndsvd0f6ppd4xq1iqhqggk890y9pdfxp0zf0d8";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0hirkls9x3x3is5yn9i035s4ph2ngdsyd8hgax5i4z6mdjzpa8vm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-5bd034f33366020f4d5137ad54218e0b978c0869/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1vqzpjq1sz9j79cf2hhbibi86bs7cqklm616j5w72z9f479dpkhf";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "17fvipwi4fx9ml4flna64ygid6mza5wnrvgj0yfkjagw4847a43r";
+      sha256 = "0230byzj04b4pkn5cnmm70jh30akdrcrn01fzmkf9wkdjsbgqnmq";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "115sixrxzch3wg7wl7rivyml0z26i0p3a4fal3j9k3w5a13a401c";
+      sha256 = "1csniqrr88h4g5i7wy3j0bgwwid2sgpdqskdrs78p5hq72ndbszz";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1b2dsja6j5gvh5k0cipxzmdfmifyc4ww0cy0439mgrzidv38d4y0";
+      sha256 = "01bxhyfwxsk1a83yraljvxcnfi2f3q5145h616lk3wkpky2gi6ha";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "13mcd854i3wlw1cqhfl68pz7vy1rlgx86ap7qwqbk3mpcpzrdc2b";
+      sha256 = "1bgvyk053bs22gyy7yksw353x82pf2c6zx38fqc4347167bcqfrq";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-18T16:16:27Z";
+  timestamp = "2025-03-20T03:18:41Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "07jzdg043845sgkccgsf6ps1kg6ca6mdjz92j2l84x9k7c25r0vp";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "19i88l8cgxj634lr9cz9jx41gz1bl1x5kdbyk89g4zc3xl8bsdyv";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1cz42y324imc4jwplvi91lmry3p5x4x9nscsdfbn9033dh2sbwkl";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "16fzvqlvgs6qba9fbd09m5a407z4h0vza03sgiv9921pl7jmm26f";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1z8y592r8w83g2n1jc7qllk5if7g5wr882i21n470fdywrnx22ja";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0b1kxj7nfrkqx1fclq84kzjg9vd1nard5rj03m4sawzdbprn1xl4";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1jcsgp7fjxfpicr78p0p2qmgbbxvy10hsypslqmjdv0cipj23sra";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-0dd4d3153764f4706c2c9857675e42dec64155a7/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "09zkzdp43gbs7k89dndcd8hhc78n4lpgqcdvdlq1q9fx4xg1w4vl";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -5,19 +5,19 @@
   sources = {
     "x86_64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1iiifa6r06g8gz2zmmmyskrvhlzgm766l1w81m04zh7mzssv08sd";
+      sha256 = "07k4s8jbla4ph30lml50ylrv9pk401355xx53sbd7iqn2hinn5pq";
     };
     "aarch64-linux" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1gb3hxm6r2zz9z7p553q11q5ppkr1yk3hych6hy4kvmbwm09l8bc";
+      sha256 = "15r1awr476k3b8yx9lfdcgpvby4rh1y985wgajw916ddz7b2i50s";
     }; 
     "x86_64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0jxjwrncbgs684a2lw03rd5zawdv9fj9ij4wa8d8jzvha9jk91zn";
+      sha256 = "0zmqpdf9pdy931i9p5j6xnnz2f904c8kjhlb6qvc4q2mc751f1dl";
     };
     "aarch64-darwin" = {
       url = "https://github.com/foundry-rs/foundry/releases/download/nightly-967a89eb5d24a7f93fc8e875dda1aeb11ec1a5fe/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "10nkkylmv0kkjdym83pmdpngmvxdd1j8h7idrh8x6bvby3hcn737";
+      sha256 = "1yq45q7s6hp4cizswap25c91n1vy3j6fig9sz1p3v1a7lkcaqmfm";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-22T08:46:28Z";
+  timestamp = "2025-03-23T16:01:04Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "08a93yhycm2ip7n8j2zyj88knrjd59ww6liw17b8c5gr9d0a5m3c";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "18fwxzwvlwl5i2n3hg8dccv8gd9lvgdl2hhvbs61bn7k2n80zjkz";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1d2pwrhi519rfyna9d1l36k36annjyr7jbpbj89cy280naasflfb";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "13nh9jxafqds3ld1vsnyjnimwvw5c0x202lffngg8wa72q6897c1";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1azyr2nj9nzjxa2jss48p77nmh2g48kbn7qc6f03a7bzcchb25sr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1mqc17v5zrqbnhnjzdcrvwllla72n7ram106br428px3yg9k2kl8";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "01wsvq118b6fsk25jiwhi5g4mkcgy9l97nqsapg65bq65l8knshn";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6e38c00b467c86531d88b1d369b434ad776fd6ea/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1ps4c791157laxkcmng5p64lwcpikfksffnk4msyr93h3vxv2qig";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-12T04:09:16Z";
+  timestamp = "2025-03-13T18:11:26Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0rp0sd62cg8629lkqa6ck6xqr73vdiwwxmpkj1ifci8z3mz142pg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "04z0zap2g0sch8l99lcrgd6ydasrk2s3ff47r1hh535x5hd4lyka";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0y3qkc4i9xykaqai8svz1g6aqrik5c5lss9a22yz5iz722x1z859";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "10jv6a1ai2fisms3l6la8b14j7cdvdavb0wz4y66rx4pcn9cjz6d";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1gg9g7bk00fdvffrbx2innmdgmp4hifixgkd7zl2jfcm70z3kf5j";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1q9f7a86lhv4h4b8vzm7ljq5a8w9xibmlf6sr5jvlyz2nacx1d4v";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7e903eb701b6746fff564d483fd84e6b69bc7020/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0ryadl0pz8ggdbvv09g8xg1fkk9jpahw267i4sf86xwpcs4kclj2";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-7c46a6e0892379e8ea06612c2269360a30d28971/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0wh7dh9vmrz58aib8b1w2cmb6dk0mmxqn9axp2ml7ydazh5sx4m3";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-21T14:30:05Z";
+  timestamp = "2025-03-22T08:46:28Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0bygxky9b2hf12y61ddsrsdckfvw6w1kiv09s7pb3nnic5n2f76n";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "08a93yhycm2ip7n8j2zyj88knrjd59ww6liw17b8c5gr9d0a5m3c";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0r1ysgi92vk3jaa07p7hff9dbnqx9k0ybwa7rx5974mpqzhldjc3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1d2pwrhi519rfyna9d1l36k36annjyr7jbpbj89cy280naasflfb";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1gj02b4dw1zhkn2xha9a1bf7iznsnqw32gdmy8b4b5h6jj1fq2b7";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1azyr2nj9nzjxa2jss48p77nmh2g48kbn7qc6f03a7bzcchb25sr";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-759b7d6f6db0bb995f22ec9cce6401c9edb82980/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "03lxg5i2c2aixwxrarhfiyqkh9f97mk4rq04r2dhx0mps44bn4hm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ab9a9e50ea4d89464c42a2665bbaaac1993429d1/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "01wsvq118b6fsk25jiwhi5g4mkcgy9l97nqsapg65bq65l8knshn";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-28T08:38:03Z";
+  timestamp = "2025-03-01T21:05:10Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1ay2bsha24h4b69m4hdnv4f38g6vyqmcy7q407i2w2dr48rjdqir";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1akgjbj8bvjpr32b9z22hn3w5dw84xbzmfkyqd2k6cpliqrcabn9";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1rz4hgdhiab0adlwqljb1sbpgjd6xnwi6mdqy9xn6q5kch8y0rxs";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "00ii9pjs58vbxsikwpyab8q0pyb68y7rvgqq3kz03xswzsaqlplr";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0bcm8grizfq1n87fas4iq34dgraqn2l8h0dc9gqv1jyja2n5v504";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "01bmnh3mmzzqczbwdg2pr1l6ffzyb73bw3i6na05lm03xk5m62vg";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-ee562e889940341f11707f9c3e933a87719ca25d/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0fzwlc4djh05zxvbwzzfq8k1w7kx94k8fa725akcdvvylj6vysp9";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f9c5a237d0bd122cf06bbc6c73b5faf3cb2b8aa1/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "09rzrpfk5p9kjxdvc64j1g8yrpdmxd74rwjwsmkiqsp1fbciimp6";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-01T21:34:38Z";
+  timestamp = "2025-04-02T13:02:55Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0ay9jcwjhwb0160djg0a9qqhn4g6a5fphp3kr1wcwdzrqp8yhxl3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "12wsjkqqqaxkzasmhcs98lig8cklkfdi895bbcf723kyf7hz4nil";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "03fjm3f1v53d2a8ra0haw8pami9zc864km7chj3gbpj9dwmhsy6j";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1hayv15kazygh93apm81w36zwmgsf7cyiqp35dj095c6lccv9xw6";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1i5q7hqv4sv4byj5y9db4qr60mdn1khni9sa8vl2a22l9jvcmkmc";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "03n1lylnhw9c4qigwv6s8f3ykvk9hzbygk055b3q4i9an9jmvhq9";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-8da73730b4033553589aa67ef404e527149c2e92/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1h9czdc16fvv40vnn902zq6vlgny7rkbs57nby9kdpga976l9bgg";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89b7470b50f2ea6ae500b8d6000ebc1b62866282/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0bb3k371nkb9vb1414v2bngq5n36p901kfa6w4w391gg2q8rp93k";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-17T16:41:46Z";
+  timestamp = "2025-02-18T16:25:33Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0an55d7148p04bajgxp641k4yb42alxhpvpgfa0jwscdjij3hhfh";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1sk1dx9w70qmrkdwm8bw8vg1hl1p3y0lwk2b5mb8hdvaixzy98ld";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1n0ga8chkd7brmin91d32ynspf935s1caxdz8x4p5iw6lf0042aq";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "15hs1pcsb94aghqjdbspaiw3hyyf0181w9j2rlc768rr0kpldi0m";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "044yyb7py04d8bbj6wwkcyjna2xaac3r3i356b9vg2id0h0nwyxk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0c3n2w6gypmdz7zdd2x8v86gk8pkx6nwq2inw5zsavflh52hn9xg";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-3d393b6f1266c71f3b422a99b1a08852534d4db3/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0ri48im43gszv1rl2hg46gv8ilql8bx1ajc5sxrsycvq008nj9aw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-97e2ebbb7f74189b65943ae0b8537415d709608c/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1mgd0j5ca4m5a5h6m2813lpy0178d0lp9fh4bg2y9sd7zgia3vvk";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-14T15:29:21Z";
+  timestamp = "2025-03-16T08:15:03Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1zh8ih559yq1ccfia571k91q74yk3db8hrjqj57si9zdm42lr29h";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0wzrsq879r74jxafp3ggjy5k0ss56sxa4c2dcq0xq4fvbkj93af5";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "12qlm13wbzsvnsh4xf31kfmxdy8wpz3wz0qac3jgj2sh4qjpayw3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1fgfg7wj7799pqm7d4xb93bq0mqrxc3958chl4mfm04fdblsws15";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "146xj4sg63kp6m5lljg15mrlh5w4dbyz6wriv24d3d9m4dic3yyv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1v1vc7nh6gzlfg3jrmf4sxxxw8ij8zk8qhwz0jb2z67rv8aynmyq";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-6ce45712a2282006c24711892400d5748f985607/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1q4mlhxa9r2hnaf8h4n5wrqcx10mw9vj4zb8kmlsmkf8m25vq85g";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1barrlazq9q4q6w6q5w8j7ip675pvrqiwgwcmk5vm52p83hwflmk";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-19T07:34:07Z";
+  timestamp = "2025-02-20T17:34:07Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "07zhljdyxzd76znv0m9rc4713bfnksfis0iydvxmcnda3vlvww1y";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0dd2v84bvd7l467kd9jbyb3hj4zp164arvbh81ci8bxp6p2x96li";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "15ilgyyd9dpxwy4s1b0zxrkihabbzjlwc7b7vjjmvh820skcy2yv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0idqh85chdijz0ncch8yzxdd9pyc1jx9qfinq4i1iadhr2ddxkli";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "16gj5v9dvc7zl2xxm69liy5sx0m3x7xh89wz7rgx06p0n56jazcp";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "15kagwwyl1143irkmbj8b17pqbyhlwlcvm3kiqpphd74wmvhysfx";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c34a752532c23aac999a3c62fdf45d0db6df2d26/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0m2g8qis0yimlnfzhd3n379kjndp6hgzrz97bqdhmr9z4b49i4b8";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-c609884bdb13b9846fe9ddc5f08d99cf30c53695/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1q83k5lar0xd8l7i369zz11qxgihb46a47rxxc4d88879mv9hy4w";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-06T10:18:36Z";
+  timestamp = "2025-04-07T19:30:32Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1g66s0yfkhmqss099wz5h3l97psq6pjf66s8pxkm0pisfbc7kf30";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1xvnhxcl0nxv2i0xkfr505bx4iw5mw42iamy0g3d0gi1zf2dyzj8";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1rsi0x8kdvv0ha1va591956dh26w6a07di8a8kzpbghp1ggh31cq";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0fx2q1b89aysri6lyzpfrzz42l57pyzh93nibiqn1fxvjmv99acg";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "01d7racb2sf1yv0sd9hmd012xpjq9jp7bgqr8cmgzjh6wxy9ppji";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "17fdm3vr8iacsfls3m237l6zdzphrlxcd7ax8gxw30nd8ypzb2ry";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-a2ecefce6fe15b574d8059a230853b8309489881/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "02fv831i0h24vcjbl6bf6z6zsj8l0z30m5f1d3x9cly2xps3lwl3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-256cc50331d8a00b86c8e1f18ca092a66e220da5/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0hirkls9x3x3is5yn9i035s4ph2ngdsyd8hgax5i4z6mdjzpa8vm";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-15T20:17:25Z";
+  timestamp = "2025-03-17T10:02:31Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1vagkrgmfbwprjw4jr79cjwnkq3wa2wva6sg789rf7d3mlwp288s";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1n0r4vj3f5c7cwyngnzdh0z7ik9w35rz3r3nm9vbjnhxh2zb4aaz";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1c8lhnk3jili1rnb90bxqmgxbp2wzaavddlc36v4c31iyig865j2";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0ji1ysbq3rpwrf0m6ic4w5h9qnl853285y5nv43rkiihys49xr5q";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1jbkmvx9044981jq6x026whvi1p957h1bh98cprd6p8cdr3bw4ii";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1mg5d54y6b155kgi4jxa97sd5sv926jlh0hgkd8kw531bsv67v20";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f47d7e0c29a36372908b917cd74aa589d5888f8e/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "15dki62pq1rnbzlzlm6fkfapxfj20iw84h298qsdaan6wgjrqsqz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1a4v5mg8v97i6z85r5awq6qj1qqq7wbk3n9mqg80479w5hfkpgfd";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-16T11:55:55Z";
+  timestamp = "2025-04-17T13:19:44Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1xcrb4q6lvrlhnn2h8vrzchi0difd3r8zz0rzyx4nbqsqc3v8k6j";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "074vx3kv5rw3pavgzchdllhmd6x5h2yi0kxl9l23apl2w2zjwgqf";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1q3k3ij2pcywhyk1dg39yzf50mqy9c4iwavxbihh34sh51imzgy0";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "14r894q9l3qck8bvkljxpq2hir80cx96i7k7bgmcarxh7cd17zgr";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "05kl6n1zz2gwp317wdzq1w0d8jjayfwvq5w65dl22m8qh7y4qr41";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0jwnmdi5yn7l2a541nppgzhbsrn9x5f95gjnqx79ggdzs9nlxqjd";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0jiq18allapa5r5lr8nhhyargh331wnaizr37i9ak385065p58zw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0ipvvhfznrf5dy29zzqmy5f6d3mv39c83fys7z9kf18jp35b2qys";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-23T19:10:05Z";
+  timestamp = "2025-02-24T14:35:04Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "189q5flm7k5liqs95wjj41dqmj1lrbjjq84ixixxljkpdridpcdk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "06x04b2m2qk4vkc09q4n6czjw1svrhika7vricsjd0g768bp3lz3";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_linux_arm64.tar.gz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_arm64.tar.gz";
       sha256 = "1pgg5z59fknibx7pdc277lq58bmn83qg85cbqdkyyzpah1wvg1yy";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1284dakw79x0gq72wcl2i4ka5x0dyak6rc93r8ayl4askxm8hvpj";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1flki2awqb6ppsw4bscm4a4dqff3rg5981plfp6kyzhdpqv5c5gw";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9066359bc017179c15e80f866369d7c9d6c060e3/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "14i3qkx44pjca06s5x4anadlvxd2a69sbahz0jr5cv5k12y1ijrk";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "15d0j8hx3gbvxzsdirjxam5z2a29l57sn4dcbkymbplbahva165r";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-03-17T10:02:31Z";
+  timestamp = "2025-03-18T16:16:27Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1n0r4vj3f5c7cwyngnzdh0z7ik9w35rz3r3nm9vbjnhxh2zb4aaz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "07jzdg043845sgkccgsf6ps1kg6ca6mdjz92j2l84x9k7c25r0vp";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0ji1ysbq3rpwrf0m6ic4w5h9qnl853285y5nv43rkiihys49xr5q";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1cz42y324imc4jwplvi91lmry3p5x4x9nscsdfbn9033dh2sbwkl";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1mg5d54y6b155kgi4jxa97sd5sv926jlh0hgkd8kw531bsv67v20";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1z8y592r8w83g2n1jc7qllk5if7g5wr882i21n470fdywrnx22ja";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-89bd12d3c3aeb3500cafdf508f0e09c505061400/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1a4v5mg8v97i6z85r5awq6qj1qqq7wbk3n9mqg80479w5hfkpgfd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e2a22506797d05e64808302a14f2292fe163ba35/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1jcsgp7fjxfpicr78p0p2qmgbbxvy10hsypslqmjdv0cipj23sra";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-24T14:35:04Z";
+  timestamp = "2025-02-25T16:15:31Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "06x04b2m2qk4vkc09q4n6czjw1svrhika7vricsjd0g768bp3lz3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0kq2h9axwrgkimi7slw6p3wnywg3xg1b6ypp05agfl0s8j8ddnqs";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1pgg5z59fknibx7pdc277lq58bmn83qg85cbqdkyyzpah1wvg1yy";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0d8w8lwjjv86198mahcirhvs3si4b1k8i3zzw1wsn5kzh0aqx526";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1flki2awqb6ppsw4bscm4a4dqff3rg5981plfp6kyzhdpqv5c5gw";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0fsy7bbf6dk5zy680mb4l5jnzrryp98agqhn4qw962gfk4kjj6gd";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "15d0j8hx3gbvxzsdirjxam5z2a29l57sn4dcbkymbplbahva165r";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-9bcfbaa6e6066fb9f87ce07163f5479d4b124563/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1ihjwj9zrmz8alqc6zkiml675avls6zm95c0k4243ah0xhmrk9qr";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-13T20:50:17Z";
+  timestamp = "2025-02-14T16:45:38Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "1brn5pcqpb4fl8hsjvwmvpchzz3dxgiaal6hflxmm8axnb5cw80f";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "17fvipwi4fx9ml4flna64ygid6mza5wnrvgj0yfkjagw4847a43r";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "0w9cdkvrc0z4h9z3yrv870wnkivmlglwsf44kygbk9i0q870zj2f";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "115sixrxzch3wg7wl7rivyml0z26i0p3a4fal3j9k3w5a13a401c";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "03qpmbi5lgifjcz9h9cigmylkvh2crhdnxkiyq2y4dmqgfi2ar3v";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "1b2dsja6j5gvh5k0cipxzmdfmifyc4ww0cy0439mgrzidv38d4y0";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "18pxd2ajvk5k9bsm443kkxvjmf0csxpd6vsx01nigrzziwpd8zji";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-51b75c83045a963a48f9cd8d765e0f2e775acb3e/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "13mcd854i3wlw1cqhfl68pz7vy1rlgx86ap7qwqbk3mpcpzrdc2b";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-11T05:36:36Z";
+  timestamp = "2025-04-15T02:29:04Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0b65kx43f2qzl72vmf2z7k2sq220fiidm79ixnkfq1d5rhsribwh";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "18pd4bqgg63mz7khqgzq34cdrblywl0mp4glgf133najfv944ppz";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "175vnk1b21v0bpi74izsh068ysqlmh13ld6ilm33bas4sqrq5dhm";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1b612qxd77z6fqws1f91pafl3x7w8rajqgxz9d7j3dvy32xicsls";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "1dvim92p8m043jn9ph8h12xnj7vqd8i6ggwig09h1608r6nq0arv";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0wrfnnmc357ck52fip0hwdkg9wpgaz2h8akk55pl76z4rzfpqp19";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-bfb1cb6b118b7e07a1de0fdea64a6cf44eb3a174/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1nlij1nk6whqvfgnjppmq2p9kn9zrghxa12jqwa31krmva5i4sj3";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "1x9xg6kb7q8ap9ym7r5yyrk3ljbh2f86id41ldvkw4fw5v8gh3kr";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-02-12T15:41:51Z";
+  timestamp = "2025-02-13T20:50:17Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e9c2eb97b21405e3b55d0881fe604b988a3bad/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "0apgn258anyifzzmgfd9vaj4q3aq8vs98clbng65wjzcraxwcw9n";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1brn5pcqpb4fl8hsjvwmvpchzz3dxgiaal6hflxmm8axnb5cw80f";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e9c2eb97b21405e3b55d0881fe604b988a3bad/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1psnwmdwfavf4cfx7z8bfj8a8zxm6p7c2j5y6sf9qzjlh9sqh17l";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "0w9cdkvrc0z4h9z3yrv870wnkivmlglwsf44kygbk9i0q870zj2f";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e9c2eb97b21405e3b55d0881fe604b988a3bad/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "048pf226cbyqxkb3s6asmglq24ndxklbg309jylvpi3hg3fph5sa";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "03qpmbi5lgifjcz9h9cigmylkvh2crhdnxkiyq2y4dmqgfi2ar3v";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f7e9c2eb97b21405e3b55d0881fe604b988a3bad/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "02kb517ii66rm9d04w20rq6v0ys9p7mxglkqkhbgacygajhaaksx";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-e5ec47b88208fdc48575359e0a5c44f85570ef63/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "18pxd2ajvk5k9bsm443kkxvjmf0csxpd6vsx01nigrzziwpd8zji";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-17T13:19:44Z";
+  timestamp = "2025-04-18T17:24:30Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "074vx3kv5rw3pavgzchdllhmd6x5h2yi0kxl9l23apl2w2zjwgqf";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "0lzrnfdbyhkzh34ajsik74l8yxiy3q532p1ffdrgwhx7z95d4ma0";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "14r894q9l3qck8bvkljxpq2hir80cx96i7k7bgmcarxh7cd17zgr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "132398av7pa0i13sppmsglilx64ya2lnfvh65jnllkd3xn5kn37d";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0jwnmdi5yn7l2a541nppgzhbsrn9x5f95gjnqx79ggdzs9nlxqjd";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "0z6lgz1g15ryxjyyvln5gs52aa0rw81zlxpm1pskx6zl46ajs9an";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-709f266ff6a26264ac4fc8c06cc40964861c7ebb/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "0ipvvhfznrf5dy29zzqmy5f6d3mv39c83fys7z9kf18jp35b2qys";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f76309dad7dddc0917755d3f3d17e1ad9d02c6b8/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0lbryw9k3iya1gw55v0siknyc15xdsdzix9jzfqirr0psrkqh58i";
     };
   };
 }

--- a/foundry-bin/releases.nix
+++ b/foundry-bin/releases.nix
@@ -1,23 +1,23 @@
 {
   version = "0.0.0";
-  timestamp = "2025-04-15T02:29:04Z";
+  timestamp = "2025-04-16T11:55:55Z";
 
   sources = {
     "x86_64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_linux_amd64.tar.gz";
-      sha256 = "18pd4bqgg63mz7khqgzq34cdrblywl0mp4glgf133najfv944ppz";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_linux_amd64.tar.gz";
+      sha256 = "1xcrb4q6lvrlhnn2h8vrzchi0difd3r8zz0rzyx4nbqsqc3v8k6j";
     };
     "aarch64-linux" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_linux_arm64.tar.gz";
-      sha256 = "1b612qxd77z6fqws1f91pafl3x7w8rajqgxz9d7j3dvy32xicsls";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_linux_arm64.tar.gz";
+      sha256 = "1q3k3ij2pcywhyk1dg39yzf50mqy9c4iwavxbihh34sh51imzgy0";
     }; 
     "x86_64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_darwin_amd64.tar.gz";
-      sha256 = "0wrfnnmc357ck52fip0hwdkg9wpgaz2h8akk55pl76z4rzfpqp19";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_darwin_amd64.tar.gz";
+      sha256 = "05kl6n1zz2gwp317wdzq1w0d8jjayfwvq5w65dl22m8qh7y4qr41";
     };
     "aarch64-darwin" = {
-      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-f0e24fb6cfc9018d986d3136ab00aa5077994994/foundry_nightly_darwin_arm64.tar.gz";
-      sha256 = "1x9xg6kb7q8ap9ym7r5yyrk3ljbh2f86id41ldvkw4fw5v8gh3kr";
+      url = "https://github.com/foundry-rs/foundry/releases/download/nightly-1da4d324652b3a61f7c7128a6d28f9d6239e8218/foundry_nightly_darwin_arm64.tar.gz";
+      sha256 = "0jiq18allapa5r5lr8nhhyargh331wnaizr37i9ak385065p58zw";
     };
   };
 }

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -11,7 +11,7 @@ function fetch_releases() {
     declare schedule="$1"
 
     if [[ "$SCHEDULE" == "stable" ]]; then
-      # "stable" release stream is marked as latest on the repo
+      # "stable" release stream is tagged "stable"
       GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/tags/stable"
       binaries='["foundry_stable_linux_amd64", "foundry_stable_linux_arm64", "foundry_stable_darwin_amd64", "foundry_stable_darwin_arm64"]'
       binaries_filter="select(.assets | map(.name) | contains(${binaries}))"

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -12,7 +12,7 @@ function fetch_releases() {
 
     if [[ "$SCHEDULE" == "stable" ]]; then
       # "stable" release stream is marked as latest on the repo
-      GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/latest"
+      GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/tags/stable"
       binaries='["foundry_stable_linux_amd64", "foundry_stable_linux_arm64", "foundry_stable_darwin_amd64", "foundry_stable_darwin_arm64"]'
       binaries_filter="select(.assets | map(.name) | contains(${binaries}))"
 


### PR DESCRIPTION
Not sure if this PR should be made against `main` or `stable` but here ya go.

Ideally the script should fail if there is no matching release, to avoid breaking the derivation, but I don't have the bandwidth to address this right now.

Closes #46 