### PR TITLE
fix: update script for stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nix overlay for [foundry-rs/foundry](https://github.com/foundry-rs/foundry/) (including `forge`, `cast`, `anvil` and `chisel`)
 
-This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release, which are pruned from upstream regularly. We also maintain a `stable` branch for the latest stable release, and a `monthly` branch for permanent nightlies that are not pruned.
+This repository is [auto-updated daily](https://github.com/shazow/foundry.nix/blob/main/.github/workflows/update-foundry-bin.yml) with the latest nightly binary release, which are pruned from upstream regularly. We also maintain a `stable` branch for the latest stable release that are not pruned.
 
 ## Usage: Showing off nix
 
@@ -43,7 +43,7 @@ Make a `flake.nix` in your solidity project directory:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
-    foundry.url = "github:shazow/foundry.nix/monthly"; # Use monthly branch for permanent releases
+    foundry.url = "github:shazow/foundry.nix/stable"; # Use stable branch for permanent releases
   };
 
   outputs = { self, nixpkgs, utils, foundry }:

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -11,7 +11,7 @@ function fetch_releases() {
     declare schedule="$1"
 
     if [[ "$SCHEDULE" == "stable" ]]; then
-      # "stable" release stream is marked as latest on the repo
+      # "stable" release stream is tagged "stable"
       GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/tags/stable"
       binaries='["foundry_stable_linux_amd64", "foundry_stable_linux_arm64", "foundry_stable_darwin_amd64", "foundry_stable_darwin_arm64"]'
       binaries_filter="select(.assets | map(.name) | contains(${binaries}))"

--- a/foundry-bin/update.sh
+++ b/foundry-bin/update.sh
@@ -12,7 +12,7 @@ function fetch_releases() {
 
     if [[ "$SCHEDULE" == "stable" ]]; then
       # "stable" release stream is marked as latest on the repo
-      GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/latest"
+      GITHUB_API_URL="https://api.github.com/repos/foundry-rs/foundry/releases/tags/stable"
       binaries='["foundry_stable_linux_amd64", "foundry_stable_linux_arm64", "foundry_stable_darwin_amd64", "foundry_stable_darwin_arm64"]'
       binaries_filter="select(.assets | map(.name) | contains(${binaries}))"
 


### PR DESCRIPTION
Ideally the script should fail if there is no matching release, to avoid breaking the derivation, but I don't have the bandwidth to address this right now.

Closes https://github.com/shazow/foundry.nix/issues/46