### PR TITLE
monthly: only run on the first 5 days of month

### DIFF
--- a/.github/workflows/update-foundry-bin-monthly.yml
+++ b/.github/workflows/update-foundry-bin-monthly.yml
@@ -3,7 +3,7 @@ name: Update foundry-bin monthly
 on:
   workflow_dispatch:
   schedule:
-    - cron: '6 9 * * *' # Run daily, the monthly release detection should be idempotent
+    - cron: '6 9 1-5 * *' # Run on the first 5 days of the month
 
 jobs:
   run:


### PR DESCRIPTION
This commit updates the monthly workflow to only run on the first 5 days of the month.

The monthly update script is unreliable with the current foundry nightly release process, it isn't able to find relevant entries later in the month. So we only run it at the start of the month and hope for the best.

cc #50 