### PR TITLE
workflows: Use main branch as source of truth for update scripts

### DIFF
--- a/.github/workflows/update-foundry-bin-daily.yml
+++ b/.github/workflows/update-foundry-bin-daily.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: main
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/update-foundry-bin-monthly.yml
+++ b/.github/workflows/update-foundry-bin-monthly.yml
@@ -11,7 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: monthly
+          ref: main
+      - name: Checkout monthly branch for committing
+        run: |
+          git fetch origin monthly
+          git checkout monthly
+          git checkout main -- foundry-bin/update.sh
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/update-foundry-bin-stable.yml
+++ b/.github/workflows/update-foundry-bin-stable.yml
@@ -11,7 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: stable
+          ref: main
+      - name: Checkout stable branch for committing
+        run: |
+          git fetch origin stable
+          git checkout stable
+          git checkout main -- foundry-bin/update.sh
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -21,5 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
+          branch: stable
           commit_message: 'foundry-bin/releases.nix: Stable update'
           commit_author: Nix Updater <actions@github.com>


### PR DESCRIPTION
This PR fixes issue #56 by making the main branch the single source of truth for update scripts.

## Changes

- Modified all three workflow files (, , )
- All workflows now start by checking out the main branch to get the latest update script
- Monthly and stable workflows fetch their respective target branches for committing
- Update script is copied from main branch using `git checkout main -- foundry-bin/update.sh`

## Benefits

- Eliminates the need to manually cherry-pick script changes across branches
- Reduces maintenance overhead and prevents bugs from version drift
- Ensures all branches always use the latest version of the update script
- Main branch becomes the single source of truth for update logic

## How it works

1. **Daily workflow** (nightly): Remains simple since it operates on main branch
2. **Monthly workflow**: Fetches monthly branch, copies update script from main, runs update, commits to monthly branch
3. **Stable workflow**: Fetches stable branch, copies update script from main, runs update, commits to stable branch

Fixes #56