### PR TITLE
feat: add rc release branch and action

### DIFF
--- a/.github/workflows/update-foundry-bin-rc.yml
+++ b/.github/workflows/update-foundry-bin-rc.yml
@@ -1,0 +1,31 @@
+name: Update foundry-bin rc
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '6 9 * * *' # Run daily
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Checkout rc branch for committing
+        run: |
+          git fetch origin rc
+          git checkout rc
+          git checkout main -- foundry-bin/update.sh
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Building package
+        run: 'cd ./foundry-bin && ./update.sh rc'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: rc
+          commit_message: 'foundry-bin/releases.nix: rc update'
+          commit_author: Nix Updater <actions@github.com>


### PR DESCRIPTION
Tested `./foundry-bin/update.sh rc` locally, it generates the release.nix file.

```nix
{
  version = "0.0.0";
  timestamp = "2025-10-01T19:57:43Z";

  sources = {
    "x86_64-linux" = {
      url = "https://github.com/foundry-rs/foundry/releases/download/v1.4.0-rc1/foundry_v1.4.0-rc1_linux_amd64.tar.gz";
      sha256 = "1sbf6sybhl2hbq8agd8dhs9sd8lidsm3dp0qjk7y12rpnak2fii7";
    };
    "aarch64-linux" = {
      url = "https://github.com/foundry-rs/foundry/releases/download/v1.4.0-rc1/foundry_v1.4.0-rc1_linux_arm64.tar.gz";
      sha256 = "0bbf6jwhvzw6wkgqyknpfs9a53h8vphn4isfpxn37mlm65fmia9q";
    }; 
    "x86_64-darwin" = {
      url = "https://github.com/foundry-rs/foundry/releases/download/v1.4.0-rc1/foundry_v1.4.0-rc1_darwin_amd64.tar.gz";
      sha256 = "156f1csn77y6846m9ys5vn1radgzyp0gsch6wcax8yc0znqrbjb4";
    };
    "aarch64-darwin" = {
      url = "https://github.com/foundry-rs/foundry/releases/download/v1.4.0-rc1/foundry_v1.4.0-rc1_darwin_arm64.tar.gz";
      sha256 = "1d11a81fn0h1iqwxrg5r0zqqlzgzm6qfqqwjvm1y5lqrak8avfn4";
    };
  };
}
```